### PR TITLE
Centralizar estilos y limpiar FXML

### DIFF
--- a/src/main/resources/css/dashboard.css
+++ b/src/main/resources/css/dashboard.css
@@ -1,19 +1,78 @@
+/* Global palette and typography */
+.root {
+    -primary-color: #4A6CF7;
+    -secondary-color: #2E8BFF;
+    -success-color: #4CAF50;
+    -danger-color: #E74C3C;
+    -warning-color: #FFC107;
+    -text-color: #333333;
+    -background-color: #F5F7FA;
+    -fx-font-family: "Segoe UI", Roboto, sans-serif;
+    -fx-text-fill: -text-color;
+}
+
+/* Layout helpers */
 .sidebar {
     -fx-background-color: rgba(0,0,0,0.2);
     -fx-padding: 10;
 }
 
+.card {
+    -fx-background-color: white;
+    -fx-background-radius: 15;
+    -fx-padding: 15;
+    -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.1), 10, 0, 0, 0);
+}
+
+/* Typography */
+.title-label {
+    -fx-font-size: 24px;
+    -fx-font-weight: bold;
+}
+
+.subtitle-label {
+    -fx-font-size: 18px;
+    -fx-font-weight: bold;
+}
+
+.error-label {
+    -fx-text-fill: -danger-color;
+    -fx-font-size: 12px;
+}
+
+/* Buttons */
 .primary-button {
-    -fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF);
+    -fx-background-color: linear-gradient(to right, -primary-color, -secondary-color);
     -fx-text-fill: white;
     -fx-font-weight: bold;
     -fx-padding: 10 20;
-    -fx-font-size: 14px;
     -fx-background-radius: 25;
     -fx-cursor: hand;
     -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);
 }
 
 .primary-button:hover {
-    -fx-background-color: linear-gradient(to right, #2E8BFF, #4A6CF7);
+    -fx-background-color: linear-gradient(to right, -secondary-color, -primary-color);
+}
+
+.danger-button {
+    -fx-background-color: -danger-color;
+    -fx-text-fill: white;
+    -fx-font-weight: bold;
+    -fx-padding: 8 15;
+    -fx-background-radius: 20;
+}
+
+.success-button {
+    -fx-background-color: -success-color;
+    -fx-text-fill: white;
+    -fx-font-weight: bold;
+    -fx-padding: 8 15;
+    -fx-background-radius: 20;
+}
+
+.input-field {
+    -fx-background-color: rgba(255,255,255,0.9);
+    -fx-background-radius: 5;
+    -fx-padding: 8 10;
 }

--- a/src/main/resources/fxml/admin_dashboard.fxml
+++ b/src/main/resources/fxml/admin_dashboard.fxml
@@ -11,12 +11,9 @@
 <BorderPane xmlns="http://javafx.com/javafx/21"
             xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="controllers.AdminDashboardController"
-            prefWidth="900" prefHeight="600"
-            style="-fx-background-color: linear-gradient(to bottom, #1e3c72, #2a5298);"
-            stylesheets="@../css/dashboard.css">
+            prefWidth="900" prefHeight="600" stylesheets="@../css/dashboard.css">
     <top>
-        <Label text="ADMIN DASHBOARD"
-               style="-fx-font-size: 24px; -fx-font-weight: bold; -fx-text-fill: white; -fx-padding:20;"/>
+        <Label text="ADMIN DASHBOARD"/>
     </top>
     <left>
         <VBox spacing="10" alignment="TOP_LEFT" styleClass="sidebar">
@@ -29,16 +26,12 @@
         </VBox>
     </left>
     <center>
-        <VBox spacing="20" alignment="TOP_CENTER" style="-fx-padding: 20;">
+        <VBox spacing="20" alignment="TOP_CENTER">
             <HBox spacing="20" alignment="CENTER">
-                <AnchorPane fx:id="cardActivos" prefWidth="200" prefHeight="120"
-                            style="-fx-background-color: rgba(76,175,80,0.9); -fx-background-radius: 15; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 10,0,0,5);"/>
-                <AnchorPane fx:id="cardInactivos" prefWidth="200" prefHeight="120"
-                            style="-fx-background-color: rgba(244,67,54,0.9); -fx-background-radius: 15; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 10,0,0,5);"/>
-                <AnchorPane fx:id="cardMembresias" prefWidth="200" prefHeight="120"
-                            style="-fx-background-color: rgba(33,150,243,0.9); -fx-background-radius: 15; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 10,0,0,5);"/>
-                <AnchorPane fx:id="cardPorVencer" prefWidth="200" prefHeight="120"
-                            style="-fx-background-color: rgba(255,152,0,0.9); -fx-background-radius: 15; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 10,0,0,5);"/>
+                <AnchorPane fx:id="cardActivos" prefWidth="200" prefHeight="120"/>
+                <AnchorPane fx:id="cardInactivos" prefWidth="200" prefHeight="120"/>
+                <AnchorPane fx:id="cardMembresias" prefWidth="200" prefHeight="120"/>
+                <AnchorPane fx:id="cardPorVencer" prefWidth="200" prefHeight="120"/>
             </HBox>
             <ListView fx:id="lstAlertas" prefHeight="150" />
             <Button text="Actividad por Recepcionista" onAction="#generarActividadRecepcionista" styleClass="primary-button"/>
@@ -47,7 +40,6 @@
         </VBox>
     </center>
     <bottom>
-        <Label fx:id="lblMensaje"
-               style="-fx-font-size: 14px; -fx-padding: 10; -fx-text-fill: white; -fx-alignment: CENTER; -fx-background-color: rgba(0,0,0,0.3); -fx-background-radius: 15 15 0 0;"/>
+        <Label fx:id="lblMensaje"/>
     </bottom>
 </BorderPane>

--- a/src/main/resources/fxml/auditoria.fxml
+++ b/src/main/resources/fxml/auditoria.fxml
@@ -2,7 +2,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.BorderPane?>
 <BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1"
-            fx:controller="controllers.AuditoriaController" prefWidth="800" prefHeight="600">
+            fx:controller="controllers.AuditoriaController" prefWidth="800" prefHeight="600" stylesheets="@../css/dashboard.css">
     <center>
         <TableView fx:id="tablaAuditoria" prefWidth="800" prefHeight="600">
             <columns>

--- a/src/main/resources/fxml/comparador_precios.fxml
+++ b/src/main/resources/fxml/comparador_precios.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.layout.*?>
 
 <BorderPane xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-            fx:controller="controllers.ComparadorPreciosController">
+            fx:controller="controllers.ComparadorPreciosController" stylesheets="@../css/dashboard.css">
     <center>
         <VBox spacing="10" alignment="TOP_CENTER">
             <ComboBox fx:id="cboEquipos" promptText="Seleccionar equipo"/>

--- a/src/main/resources/fxml/components/metric_card.fxml
+++ b/src/main/resources/fxml/components/metric_card.fxml
@@ -7,22 +7,10 @@
 
 <VBox xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="controllers.MetricCardController"
-      style="-fx-background-color: #ffffff;
-             -fx-border-radius: 10px;
-             -fx-background-radius: 10px;
-             -fx-padding: 15px;
-             -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.15), 6, 0.3, 0, 2);
-             -fx-cursor: hand;"
       spacing="5" alignment="CENTER"
-      prefWidth="200" prefHeight="120">
+      prefWidth="200" prefHeight="120" stylesheets="@../../css/dashboard.css">
 
-    <Label fx:id="lblTitulo"
-           style="-fx-font-size: 14px;
-                  -fx-text-fill: #666666;
-                  -fx-font-weight: bold;"/>
+    <Label fx:id="lblTitulo"/>
 
-    <Label fx:id="lblValor"
-           style="-fx-font-size: 22px;
-                  -fx-font-weight: bold;
-                  -fx-text-fill: #1e88e5;"/>
+    <Label fx:id="lblValor"/>
 </VBox>

--- a/src/main/resources/fxml/confirmar_edicion_dialog.fxml
+++ b/src/main/resources/fxml/confirmar_edicion_dialog.fxml
@@ -9,48 +9,29 @@
 <VBox xmlns="http://javafx.com/javafx/17"
       xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="controllers.ConfirmarEdicionDialogController"
-      style="-fx-background-color: #ffffff;
-            -fx-background-radius: 15;
-            -fx-border-radius: 15;
-            -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.2), 10, 0, 0, 3);"
       spacing="15"
       alignment="CENTER"
       prefWidth="400"
-      prefHeight="250">
+      prefHeight="250" stylesheets="@../css/dashboard.css">
 
-    <Label text="✏️"
-           style="-fx-font-size: 48px; -fx-text-fill: #4A6CF7;" />
+    <Label text="✏️" />
 
     <Label fx:id="lblTitulo"
-           text="Confirmar Edición"
-           style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: #4A6CF7;" />
+           text="Confirmar Edición" />
 
     <Label text="¿Desea editar los datos de este cliente?"
-           style="-fx-font-size: 14px; -fx-text-fill: #555555; -fx-wrap-text: true;"
            maxWidth="350"
            textAlignment="CENTER" />
 
     <Label fx:id="lblNombreCliente"
-           style="-fx-font-size: 16px; -fx-font-weight: bold; -fx-text-fill: #333333;"
            maxWidth="350"
            textAlignment="CENTER" />
 
-    <HBox spacing="20" alignment="CENTER" style="-fx-padding: 10 0 0 0;">
+    <HBox spacing="20" alignment="CENTER">
         <Button fx:id="btnCancelar"
-                text="Cancelar"
-                style="-fx-background-color: transparent;
-                       -fx-text-fill: #6C757D;
-                       -fx-font-weight: bold;
-                       -fx-border-color: #6C757D;
-                       -fx-border-radius: 20;
-                       -fx-padding: 8 20;"/>
+                text="Cancelar"/>
 
         <Button fx:id="btnConfirmar"
-                text="Confirmar"
-                style="-fx-background-color: #4A6CF7;
-                       -fx-text-fill: white;
-                       -fx-font-weight: bold;
-                       -fx-background-radius: 20;
-                       -fx-padding: 8 20;"/>
+                text="Confirmar"/>
     </HBox>
 </VBox>

--- a/src/main/resources/fxml/confirmar_eliminacion_dialog.fxml
+++ b/src/main/resources/fxml/confirmar_eliminacion_dialog.fxml
@@ -9,53 +9,33 @@
 <VBox xmlns="http://javafx.com/javafx/17"
       xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="controllers.ConfirmarEliminacionDialogController"
-      style="-fx-background-color: #ffffff;
-            -fx-background-radius: 15;
-            -fx-border-radius: 15;
-            -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.2), 10, 0, 0, 3);"
       spacing="15"
       alignment="CENTER"
       prefWidth="400"
-      prefHeight="250">
+      prefHeight="250" stylesheets="@../css/dashboard.css">
 
-    <Label text="⚠️"
-           style="-fx-font-size: 48px; -fx-text-fill: #DC3545;" />
+    <Label text="⚠️" />
 
-    <Label text="Confirmar Eliminación"
-           style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: #DC3545;" />
+    <Label text="Confirmar Eliminación" />
 
     <Label fx:id="lblPregunta"
            text="¿Eliminar permanentemente este elemento?"
-           style="-fx-font-size: 14px; -fx-text-fill: #555555; -fx-wrap-text: true;"
            maxWidth="350"
            textAlignment="CENTER" />
 
     <Label fx:id="lblNombreCliente"
-           style="-fx-font-size: 16px; -fx-font-weight: bold; -fx-text-fill: #333333;"
            maxWidth="350"
            textAlignment="CENTER" />
 
     <Label text="⚠️ Esta acción borrará todos los registros asociados"
-           style="-fx-font-size: 13px; -fx-text-fill: #DC3545; -fx-font-style: italic; -fx-wrap-text: true;"
            maxWidth="350"
            textAlignment="CENTER" />
 
-    <HBox spacing="20" alignment="CENTER" style="-fx-padding: 10 0 0 0;">
+    <HBox spacing="20" alignment="CENTER">
         <Button fx:id="btnCancelar"
-                text="Cancelar"
-                style="-fx-background-color: transparent;
-                       -fx-text-fill: #6C757D;
-                       -fx-font-weight: bold;
-                       -fx-border-color: #6C757D;
-                       -fx-border-radius: 20;
-                       -fx-padding: 8 20;"/>
+                text="Cancelar"/>
 
         <Button fx:id="btnEliminar"
-                text="Eliminar"
-                style="-fx-background-color: #DC3545;
-                       -fx-text-fill: white;
-                       -fx-font-weight: bold;
-                       -fx-background-radius: 20;
-                       -fx-padding: 8 20;"/>
+                text="Eliminar"/>
     </HBox>
 </VBox>

--- a/src/main/resources/fxml/dashboard.fxml
+++ b/src/main/resources/fxml/dashboard.fxml
@@ -13,82 +13,48 @@
 <BorderPane xmlns="http://javafx.com/javafx/21"
             xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="controllers.DashboardController"
-            prefWidth="900" prefHeight="600"
-            style="-fx-background-color: linear-gradient(to bottom, #1e3c72, #2a5298);">
+            prefWidth="900" prefHeight="600" stylesheets="@../css/dashboard.css">
 
     <top>
-        <VBox alignment="CENTER" style="-fx-background-color: rgba(0,0,0,0.3); -fx-background-radius: 0 0 15 15; -fx-padding: 15;">
-            <Label text="PANEL DE CONTROL"
-                   style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: #FFD700; -fx-padding: 0 0 5 0;"/>
-            <Label text="Dashboard"
-                   style="-fx-font-size: 28px; -fx-font-weight: bold; -fx-text-fill: white; -fx-padding: 0 0 15 0;"/>
+        <VBox alignment="CENTER">
+            <Label text="PANEL DE CONTROL"/>
+            <Label text="Dashboard"/>
         </VBox>
     </top>
 
     <center>
-        <VBox spacing="20" alignment="TOP_CENTER" prefWidth="1100" style="-fx-padding: 20;">
+        <VBox spacing="20" alignment="TOP_CENTER" prefWidth="1100">
             <HBox spacing="20" alignment="CENTER">
-                <AnchorPane fx:id="cardClientes" prefWidth="200" prefHeight="120"
-                            style="-fx-background-color: rgba(76,175,80,0.9); -fx-background-radius: 15;
-                                   -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 10, 0, 0, 5);"/>
-                <AnchorPane fx:id="cardPagos" prefWidth="200" prefHeight="120"
-                            style="-fx-background-color: rgba(33,150,243,0.9); -fx-background-radius: 15;
-                                   -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 10, 0, 0, 5);"/>
-                <AnchorPane fx:id="cardVencimientos" prefWidth="200" prefHeight="120"
-                            style="-fx-background-color: rgba(255,152,0,0.9); -fx-background-radius: 15;
-                                   -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 10, 0, 0, 5);"/>
+                <AnchorPane fx:id="cardClientes" prefWidth="200" prefHeight="120"/>
+                <AnchorPane fx:id="cardPagos" prefWidth="200" prefHeight="120"/>
+                <AnchorPane fx:id="cardVencimientos" prefWidth="200" prefHeight="120"/>
             </HBox>
 
-            <Label text="Clientes Próximos a Vencer"
-                   style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: white; -fx-padding: 10 0 5 0;"/>
+            <Label text="Clientes Próximos a Vencer"/>
 
-            <TableView fx:id="tablaClientesProximosAVencer" prefHeight="400"
-                       style="-fx-background-color: rgba(255,255,255,0.1); -fx-background-radius: 15;
-                              -fx-border-radius: 15; -fx-border-color: rgba(255,255,255,0.2);">
+            <TableView fx:id="tablaClientesProximosAVencer" prefHeight="400">
                 <columns>
-                    <TableColumn fx:id="colAlerta" prefWidth="50" sortable="false" resizable="false"
-                                 style="-fx-alignment: CENTER; -fx-text-fill: white;" text=" "/>
-                    <TableColumn text="Cliente" prefWidth="250" fx:id="colCliente"
-                                 style="-fx-alignment: CENTER; -fx-text-fill: white;"/>
-                    <TableColumn text="Teléfono" prefWidth="150" fx:id="colTelefono"
-                                 style="-fx-alignment: CENTER; -fx-text-fill: white;"/>
-                    <TableColumn text="Vencimiento" prefWidth="150" fx:id="colVencimiento"
-                                 style="-fx-alignment: CENTER; -fx-text-fill: white;"/>
-                    <TableColumn text="Días Restantes" prefWidth="150" fx:id="colDiasRestantes"
-                                 style="-fx-alignment: CENTER; -fx-text-fill: white;"/>
-                    <TableColumn text="Acciones" fx:id="colAccion" prefWidth="110" resizable="false" sortable="false"
-                                 style="-fx-alignment: CENTER; -fx-text-fill: white;"/>
+                    <TableColumn fx:id="colAlerta" prefWidth="50" sortable="false" resizable="false" text=" "/>
+                    <TableColumn text="Cliente" prefWidth="250" fx:id="colCliente"/>
+                    <TableColumn text="Teléfono" prefWidth="150" fx:id="colTelefono"/>
+                    <TableColumn text="Vencimiento" prefWidth="150" fx:id="colVencimiento"/>
+                    <TableColumn text="Días Restantes" prefWidth="150" fx:id="colDiasRestantes"/>
+                    <TableColumn text="Acciones" fx:id="colAccion" prefWidth="110" resizable="false" sortable="false"/>
                 </columns>
             </TableView>
 
             <HBox spacing="10" alignment="CENTER_RIGHT">
                 <Region fx:id="regionSpacer" HBox.hgrow="ALWAYS"/>
-                <Button text="Registrar Cliente" onAction="#handleRegistroCliente"
-                        style="-fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF); -fx-text-fill: white; -fx-font-weight: bold;
-                               -fx-padding: 10 20; -fx-font-size: 14px; -fx-background-radius: 25; -fx-cursor: hand;
-                               -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
-                <Button text="Registrar Coach" onAction="#handleRegistroCoach"
-                        style="-fx-background-color: linear-gradient(to right, #9b59b6, #8e44ad); -fx-text-fill: white; -fx-font-weight: bold; -fx-padding: 10 20; -fx-font-size: 14px; -fx-background-radius: 25; -fx-cursor: hand;
-                -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
-                <Button text="Inventario" onAction="#abrirInventario"
-                        style="-fx-background-color: linear-gradient(to right, #e67e22, #e74c3c); -fx-text-fill: white; -fx-font-weight: bold;
-                               -fx-padding: 10 20; -fx-font-size: 14px; -fx-background-radius: 25; -fx-cursor: hand;
-                               -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
-                <Button text="Finalizar turno" onAction="#handleFinalizarTurno"
-                        style="-fx-background-color: linear-gradient(to right, #c0392b, #8e0e00); -fx-text-fill: white; -fx-font-weight: bold;
-                               -fx-padding: 10 20; -fx-font-size: 14px; -fx-background-radius: 25; -fx-cursor: hand;
-                               -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
-                <!--Button text="Ver Todos" fx:id="btnVerTodos" onAction="#handleVerTodos"
-                        style="-fx-background-color: linear-gradient(to right, #9b59b6, #8e44ad); -fx-text-fill: white; -fx-font-weight: bold;
-                               -fx-padding: 10 20; -fx-font-size: 14px; -fx-background-radius: 25; -fx-cursor: hand;
-                               -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/-->
+                <Button text="Registrar Cliente" onAction="#handleRegistroCliente"/>
+                <Button text="Registrar Coach" onAction="#handleRegistroCoach"/>
+                <Button text="Inventario" onAction="#abrirInventario"/>
+                <Button text="Finalizar turno" onAction="#handleFinalizarTurno"/>
+                <!--Button text="Ver Todos" fx:id="btnVerTodos" onAction="#handleVerTodos"/-->
             </HBox>
         </VBox>
     </center>
 
     <bottom>
-        <Label fx:id="lblMensaje"
-               style="-fx-font-size: 14px; -fx-padding: 10; -fx-text-fill: white; -fx-alignment: CENTER;
-                      -fx-background-color: rgba(0,0,0,0.3); -fx-background-radius: 15 15 0 0;"/>
+        <Label fx:id="lblMensaje"/>
     </bottom>
 </BorderPane>

--- a/src/main/resources/fxml/editar_cliente.fxml
+++ b/src/main/resources/fxml/editar_cliente.fxml
@@ -8,49 +8,37 @@
 <VBox xmlns="http://javafx.com/javafx/17"
       xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="controllers.EditarClienteController"
-      style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e);"
       spacing="20"
       alignment="TOP_CENTER"
       prefWidth="500"
-      prefHeight="450">
-    <StackPane style="-fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF); -fx-padding: 25 0; -fx-background-radius: 0 0 20 20;">
+      prefHeight="450" stylesheets="@../css/dashboard.css">
+    <StackPane>
         <HBox alignment="CENTER" spacing="10">
             <ImageView fitWidth="40" fitHeight="40">
                 <Image url="/images/gym.png" />
             </ImageView>
-            <Label text="Editar Cliente"
-                   style="-fx-font-size: 24px; -fx-font-weight: bold; -fx-text-fill: white;"/>
+            <Label text="Editar Cliente"/>
         </HBox>
     </StackPane>
-    <VBox alignment="CENTER" spacing="20" style="-fx-padding: 0 30;">
+    <VBox alignment="CENTER" spacing="20">
         <GridPane hgap="15" vgap="15" alignment="CENTER">
             <columnConstraints>
                 <ColumnConstraints prefWidth="120" halignment="RIGHT"/>
                 <ColumnConstraints prefWidth="300" halignment="LEFT"/>
             </columnConstraints>
-            <Label text="Nombres:" GridPane.rowIndex="0" GridPane.columnIndex="0"
-                   style="-fx-font-size: 14px; -fx-text-fill: white; -fx-font-weight: bold;"/>
-            <TextField fx:id="txtNombres" GridPane.rowIndex="0" GridPane.columnIndex="1"
-                       style="-fx-font-size: 14px; -fx-pref-width: 250px; -fx-background-radius: 5; -fx-background-color: rgba(255,255,255,0.9);"/>
-            <Label fx:id="lblErrorNombres" style="-fx-text-fill: #ff6b6b; -fx-font-size: 12px;" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
-            <Label text="Apellidos:" GridPane.rowIndex="2" GridPane.columnIndex="0"
-                   style="-fx-font-size: 14px; -fx-text-fill: white; -fx-font-weight: bold;"/>
-            <TextField fx:id="txtApellidos" GridPane.rowIndex="2" GridPane.columnIndex="1"
-                       style="-fx-font-size: 14px; -fx-pref-width: 250px; -fx-background-radius: 5; -fx-background-color: rgba(255,255,255,0.9);"/>
-            <Label fx:id="lblErrorApellidos" style="-fx-text-fill: #ff6b6b; -fx-font-size: 12px;" GridPane.rowIndex="3" GridPane.columnIndex="1"/>
-            <Label text="Teléfono:" GridPane.rowIndex="4" GridPane.columnIndex="0"
-                   style="-fx-font-size: 14px; -fx-text-fill: white; -fx-font-weight: bold;"/>
-            <TextField fx:id="txtTelefono" GridPane.rowIndex="4" GridPane.columnIndex="1"
-                       style="-fx-font-size: 14px; -fx-pref-width: 250px; -fx-background-radius: 5; -fx-background-color: rgba(255,255,255,0.9);"/>
-            <Label fx:id="lblErrorTelefono" style="-fx-text-fill: #ff6b6b; -fx-font-size: 12px;" GridPane.rowIndex="5" GridPane.columnIndex="1"/>
+            <Label text="Nombres:" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+            <TextField fx:id="txtNombres" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+            <Label fx:id="lblErrorNombres" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
+            <Label text="Apellidos:" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
+            <TextField fx:id="txtApellidos" GridPane.rowIndex="2" GridPane.columnIndex="1"/>
+            <Label fx:id="lblErrorApellidos" GridPane.rowIndex="3" GridPane.columnIndex="1"/>
+            <Label text="Teléfono:" GridPane.rowIndex="4" GridPane.columnIndex="0"/>
+            <TextField fx:id="txtTelefono" GridPane.rowIndex="4" GridPane.columnIndex="1"/>
+            <Label fx:id="lblErrorTelefono" GridPane.rowIndex="5" GridPane.columnIndex="1"/>
         </GridPane>
         <HBox spacing="20" alignment="CENTER">
-            <Button fx:id="btnCancelar" text="CANCELAR"
-                    style="-fx-background-color: #6C757D; -fx-text-fill: white; -fx-font-weight: bold;
-                           -fx-font-size: 14px; -fx-background-radius: 25; -fx-padding: 10 30; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
-            <Button fx:id="btnGuardar" text="GUARDAR CAMBIOS" onAction="#handleGuardar"
-                    style="-fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF); -fx-text-fill: white; -fx-font-weight: bold;
-                           -fx-font-size: 14px; -fx-background-radius: 25; -fx-padding: 10 30; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
+            <Button fx:id="btnCancelar" text="CANCELAR"/>
+            <Button fx:id="btnGuardar" text="GUARDAR CAMBIOS" onAction="#handleGuardar"/>
         </HBox>
     </VBox>
     <effect>

--- a/src/main/resources/fxml/finalizar_turno.fxml
+++ b/src/main/resources/fxml/finalizar_turno.fxml
@@ -3,11 +3,11 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <VBox xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1"
-      fx:controller="controllers.FinalizarTurnoController" spacing="10" alignment="CENTER">
+      fx:controller="controllers.FinalizarTurnoController" spacing="10" alignment="CENTER" stylesheets="@../css/dashboard.css">
     <padding>
         <Insets top="20" right="20" bottom="20" left="20"/>
     </padding>
-    <Label text="Resumen del Turno" style="-fx-font-size:18px;-fx-font-weight:bold;"/>
+    <Label text="Resumen del Turno"/>
     <GridPane hgap="10" vgap="10">
         <Label text="Stock inicial:" GridPane.columnIndex="0" GridPane.rowIndex="0"/>
         <Label fx:id="lblStockInicial" GridPane.columnIndex="1" GridPane.rowIndex="0"/>

--- a/src/main/resources/fxml/ingresos_mensuales.fxml
+++ b/src/main/resources/fxml/ingresos_mensuales.fxml
@@ -10,21 +10,16 @@
 <AnchorPane xmlns="http://javafx.com/javafx/21"
             xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="controllers.IngresosMensualesController"
-            prefHeight="800" prefWidth="1200"
-            style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e);">
+            prefHeight="800" prefWidth="1200" stylesheets="@../css/dashboard.css">
     <children>
         <VBox spacing="20" AnchorPane.topAnchor="20" AnchorPane.rightAnchor="20" AnchorPane.leftAnchor="20" AnchorPane.bottomAnchor="20">
-            <HBox spacing="20" alignment="CENTER_LEFT" style="-fx-padding: 0 0 15 0;">
-                <Label text="Análisis de Ingresos Mensuales"
-                       style="-fx-font-size: 24px; -fx-font-weight: bold; -fx-text-fill: white;"/>
+            <HBox spacing="20" alignment="CENTER_LEFT">
+                <Label text="Análisis de Ingresos Mensuales"/>
                 <Region HBox.hgrow="ALWAYS"/>
-                <Label text="Seleccionar Año:" style="-fx-font-weight: bold; -fx-text-fill: white;"/>
-                <ComboBox fx:id="cbAnio" prefWidth="100" style="-fx-background-color: rgba(255,255,255,0.9);"/>
-                <Button fx:id="btnExportarPDF" text="Exportar a PDF" onAction="#handleExportarPDF"
-                        style="-fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF); -fx-text-fill: white;
-                               -fx-font-weight: bold; -fx-padding: 8 15; -fx-background-radius: 25; -fx-cursor: hand; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
+                <Label text="Seleccionar Año:"/>
+                <ComboBox fx:id="cbAnio" prefWidth="100"/>
+                <Button fx:id="btnExportarPDF" text="Exportar a PDF" onAction="#handleExportarPDF"/>
                 <Button fx:id="btnRegistrarEgreso" text="Registrar Egreso"
-                        style="-fx-background-color: linear-gradient(to right, #e67e22, #e74c3c); -fx-text-fill: white; -fx-font-weight: bold; -fx-padding: 8 15; -fx-background-radius: 25;"
                         GridPane.columnIndex="3" GridPane.rowIndex="0"/>
             </HBox>
             <GridPane hgap="20" vgap="20">
@@ -33,57 +28,52 @@
                     <ColumnConstraints percentWidth="40"/>
                 </columnConstraints>
                 <VBox GridPane.columnIndex="0" spacing="20">
-                    <Label text="Ingresos Mensuales" style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: white;"/>
-                    <BarChart fx:id="barChart" title="" categoryGap="15" barGap="5" animated="false" prefHeight="250"
-                              style="-fx-background-color: rgba(255,255,255,0.1); -fx-background-radius: 15; -fx-border-radius: 15; -fx-border-color: rgba(255,255,255,0.2);">
+                    <Label text="Ingresos Mensuales"/>
+                    <BarChart fx:id="barChart" title="" categoryGap="15" barGap="5" animated="false" prefHeight="250">
                         <xAxis>
-                            <CategoryAxis label="Mes" style="-fx-tick-label-fill: white;"/>
+                            <CategoryAxis label="Mes"/>
                         </xAxis>
                         <yAxis>
-                            <NumberAxis label="Monto ($)" style="-fx-tick-label-fill: white;"/>
+                            <NumberAxis label="Monto ($)"/>
                         </yAxis>
                     </BarChart>
-                    <Label text="Detalle de Pagos" style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: white;"/>
-                    <TableView fx:id="tablaDetalles" prefHeight="200"
-                               style="-fx-background-color: rgba(255,255,255,0.1); -fx-background-radius: 15; -fx-border-radius: 15; -fx-border-color: rgba(255,255,255,0.2);">
+                    <Label text="Detalle de Pagos"/>
+                    <TableView fx:id="tablaDetalles" prefHeight="200">
                         <columns>
-                            <TableColumn fx:id="colFecha" text="Fecha" prefWidth="100" style="-fx-text-fill: white;"/>
-                            <TableColumn fx:id="colCliente" text="Cliente" prefWidth="100" style="-fx-text-fill: white;"/>
-                            <TableColumn fx:id="colMembresia" text="Membresía" prefWidth="120" style="-fx-text-fill: white;"/>
-                            <TableColumn fx:id="colMonto" text="Monto" prefWidth="100" style="-fx-text-fill: white;"/>
+                            <TableColumn fx:id="colFecha" text="Fecha" prefWidth="100"/>
+                            <TableColumn fx:id="colCliente" text="Cliente" prefWidth="100"/>
+                            <TableColumn fx:id="colMembresia" text="Membresía" prefWidth="120"/>
+                            <TableColumn fx:id="colMonto" text="Monto" prefWidth="100"/>
                         </columns>
                     </TableView>
-                    <Label text="Detalle de Egresos" style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: white;"/>
-                    <TableView fx:id="tablaEgresos" prefHeight="200"
-                               style="-fx-background-color: rgba(255,255,255,0.1); -fx-background-radius: 15; -fx-border-radius: 15; -fx-border-color: rgba(255,255,255,0.2);">
+                    <Label text="Detalle de Egresos"/>
+                    <TableView fx:id="tablaEgresos" prefHeight="200">
                         <columns>
-                            <TableColumn fx:id="colFechaEgreso" text="Fecha" prefWidth="100" style="-fx-text-fill: white;"/>
-                            <TableColumn fx:id="colDescripcion" text="Descripción" prefWidth="290" style="-fx-text-fill: white;"/>
-                            <TableColumn fx:id="colCategoria" text="Categoría" prefWidth="150" style="-fx-text-fill: white;"/>
-                            <TableColumn fx:id="colMontoEgreso" text="Monto" prefWidth="120" style="-fx-text-fill: white;"/>
+                            <TableColumn fx:id="colFechaEgreso" text="Fecha" prefWidth="100"/>
+                            <TableColumn fx:id="colDescripcion" text="Descripción" prefWidth="290"/>
+                            <TableColumn fx:id="colCategoria" text="Categoría" prefWidth="150"/>
+                            <TableColumn fx:id="colMontoEgreso" text="Monto" prefWidth="120"/>
                         </columns>
                     </TableView>
                 </VBox>
                 <VBox GridPane.columnIndex="1" spacing="20">
-                    <Label text="Distribución de Membresías" style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: white;"/>
-                    <PieChart fx:id="pieChart" title="" prefHeight="250"
-                              style="-fx-background-color: rgba(255,255,255,0.1); -fx-background-radius: 15; -fx-border-radius: 15; -fx-border-color: rgba(255,255,255,0.2);"/>
-                    <VBox spacing="15" style="-fx-background-color: rgba(255,255,255,0.1); -fx-background-radius: 15; -fx-padding: 20; -fx-border-color: rgba(255,255,255,0.2);">
-                        <Label text="Métricas Clave" style="-fx-font-size: 18px; -fx-font-weight: bold; -fx-text-fill: white; -fx-padding: 0 0 10 0;"/>
+                    <Label text="Distribución de Membresías"/>
+                    <PieChart fx:id="pieChart" title="" prefHeight="250"/>
+                    <VBox spacing="15">
+                        <Label text="Métricas Clave"/>
                         <GridPane hgap="15" vgap="15">
-                            <Label text="Total Anual:" style="-fx-font-weight: bold; -fx-text-fill: white;" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
-                            <Label fx:id="lblTotalAnual" style="-fx-font-weight: bold; -fx-text-fill: #27ae60; -fx-font-size: 16px;" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
-                            <Label text="Promedio Mensual:" style="-fx-font-weight: bold; -fx-text-fill: white;" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
-                            <Label fx:id="lblPromedioMensual" style="-fx-font-weight: bold; -fx-text-fill: #3498db; -fx-font-size: 16px;" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
-                            <Label text="Mejor Mes:" style="-fx-font-weight: bold; -fx-text-fill: white;" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
-                            <Label fx:id="lblMejorMes" style="-fx-font-weight: bold; -fx-text-fill: #e74c3c; -fx-font-size: 16px;" GridPane.rowIndex="2" GridPane.columnIndex="1"/>
+                            <Label text="Total Anual:" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+                            <Label fx:id="lblTotalAnual" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+                            <Label text="Promedio Mensual:" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+                            <Label fx:id="lblPromedioMensual" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
+                            <Label text="Mejor Mes:" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
+                            <Label fx:id="lblMejorMes" GridPane.rowIndex="2" GridPane.columnIndex="1"/>
                         </GridPane>
                     </VBox>
                 </VBox>
             </GridPane>
-            <HBox spacing="20" alignment="CENTER_RIGHT" style="-fx-padding: 20 0 0 0;">
-                <Button text="Volver" onAction="#handleVolver"
-                        style="-fx-background-color: #6C757D; -fx-text-fill: white; -fx-font-weight: bold; -fx-padding: 8 25; -fx-background-radius: 25; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
+            <HBox spacing="20" alignment="CENTER_RIGHT">
+                <Button text="Volver" onAction="#handleVolver"/>
             </HBox>
         </VBox>
     </children>

--- a/src/main/resources/fxml/inventario_equipos.fxml
+++ b/src/main/resources/fxml/inventario_equipos.fxml
@@ -4,16 +4,13 @@
 
 <BorderPane xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="controllers.InventarioEquiposController"
-            prefWidth="800" prefHeight="600"
-            style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e); -fx-padding: 15;">
+            prefWidth="800" prefHeight="600" stylesheets="@../css/dashboard.css">
     <top>
         <Label text="Inventario de Equipos"
-               style="-fx-font-size: 20px; -fx-font-weight: bold; -fx-text-fill: white;"
                BorderPane.alignment="CENTER"/>
     </top>
     <center>
-        <TableView fx:id="tablaEquipos" VBox.vgrow="ALWAYS"
-                   style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-radius: 10; -fx-background-radius: 10;">
+        <TableView fx:id="tablaEquipos" VBox.vgrow="ALWAYS">
             <columns>
                 <TableColumn text="EQUIPO" fx:id="colNombre" prefWidth="200"/>
                 <TableColumn text="MARCA" fx:id="colMarca" prefWidth="120"/>
@@ -25,7 +22,7 @@
         </TableView>
     </center>
     <bottom>
-        <HBox spacing="10" alignment="CENTER_RIGHT" style="-fx-padding:10;">
+        <HBox spacing="10" alignment="CENTER_RIGHT">
             <Button text="Registrar Equipo" onAction="#handleRegistrarEquipo"/>
             <Button text="Actualizar Stock" onAction="#handleActualizarStock"/>
             <Button text="Subir PDF" onAction="#handleSubirPdf"/>

--- a/src/main/resources/fxml/inventario_ventas.fxml
+++ b/src/main/resources/fxml/inventario_ventas.fxml
@@ -6,10 +6,9 @@
 <?import javafx.scene.control.cell.PropertyValueFactory?>
 <BorderPane xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="controllers.InventarioController"
-            prefWidth="800" prefHeight="600" style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e); -fx-padding: 15;">
+            prefWidth="800" prefHeight="600" stylesheets="@../css/dashboard.css">
     <top>
         <Label text="Gestión de Inventario y Ventas"
-               style="-fx-font-size: 20px; -fx-font-weight: bold; -fx-text-fill: white; -fx-padding: 0 0 10 0;"
                alignment="CENTER" maxWidth="Infinity"/>
     </top>
     <center>
@@ -24,10 +23,10 @@
             </rowConstraints>
 
             <!-- VENDER PRODUCTO -->
-            <VBox style="-fx-background-color: rgba(255,235,238,0.2); -fx-padding: 15; -fx-border-color: rgba(255,205,210,0.5); -fx-border-width: 1; -fx-border-radius: 15; -fx-background-radius: 15;"
+            <VBox
                   spacing="10" GridPane.rowIndex="0" GridPane.columnIndex="1" VBox.vgrow="ALWAYS">
-                <Label text="VENDER PRODUCTO" style="-fx-font-weight: bold; -fx-font-size: 14px; -fx-text-fill: white;"/>
-                <GridPane hgap="10" vgap="10" style="-fx-padding: 10 0;">
+                <Label text="VENDER PRODUCTO"/>
+                <GridPane hgap="10" vgap="10">
                     <columnConstraints>
                         <ColumnConstraints prefWidth="150"/>
                         <ColumnConstraints prefWidth="200"/>
@@ -37,93 +36,70 @@
                         <RowConstraints prefHeight="30"/>
                         <RowConstraints prefHeight="30"/>
                     </rowConstraints>
-                    <Label text="SELECCIONE PRODUCTO" GridPane.rowIndex="0" GridPane.columnIndex="0" style="-fx-text-fill: white;"/>
-                    <ComboBox fx:id="cbProductos" GridPane.rowIndex="0" GridPane.columnIndex="1" prefWidth="200" style="-fx-background-color: rgba(255,255,255,0.9);"/>
-                    <Label text="UNIDADES A VENDER" GridPane.rowIndex="1" GridPane.columnIndex="0" style="-fx-text-fill: white;"/>
+                    <Label text="SELECCIONE PRODUCTO" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+                    <ComboBox fx:id="cbProductos" GridPane.rowIndex="0" GridPane.columnIndex="1" prefWidth="200"/>
+                    <Label text="UNIDADES A VENDER" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
                     <HBox spacing="10" alignment="CENTER_LEFT" GridPane.rowIndex="1" GridPane.columnIndex="1">
-                        <Button text="-" onAction="#disminuirCantidad" style="-fx-background-color: #6C757D; -fx-text-fill: white;"/>
-                        <Label fx:id="lblCantidad" text="1" style="-fx-font-size: 14px; -fx-font-weight: bold; -fx-text-fill: white;"/>
-                        <Button text="+" onAction="#aumentarCantidad" style="-fx-background-color: #6C757D; -fx-text-fill: white;"/>
+                        <Button text="-" onAction="#disminuirCantidad"/>
+                        <Label fx:id="lblCantidad" text="1"/>
+                        <Button text="+" onAction="#aumentarCantidad"/>
                     </HBox>
-                    <Label text="TOTAL:" GridPane.rowIndex="2" GridPane.columnIndex="0" style="-fx-font-weight: bold; -fx-text-fill: white;"/>
-                    <Label fx:id="lblTotalVenta" GridPane.rowIndex="2" GridPane.columnIndex="1" style="-fx-font-weight: bold; -fx-font-size: 14px; -fx-text-fill: white;"/>
+                    <Label text="TOTAL:" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
+                    <Label fx:id="lblTotalVenta" GridPane.rowIndex="2" GridPane.columnIndex="1"/>
                 </GridPane>
-                <Button text="Agregar al Carrito" onAction="#handleAgregarAlCarrito"
-                        style="-fx-background-color: linear-gradient(to right, #e67e22, #e74c3c); -fx-text-fill: white; -fx-font-weight: bold; -fx-background-radius: 25;"/>
+                <Button text="Agregar al Carrito" onAction="#handleAgregarAlCarrito"/>
             </VBox>
 
             <!-- PRODUCTOS INGRESADOS -->
-            <VBox style="-fx-background-color: rgba(255,253,231,0.2); -fx-padding: 15; -fx-border-color: rgba(255,249,196,0.5); -fx-border-width: 1; -fx-border-radius: 15; -fx-background-radius: 15;"
+            <VBox
                   spacing="10" GridPane.rowIndex="0" GridPane.columnIndex="0" GridPane.rowSpan="2" VBox.vgrow="ALWAYS">
-                <Label text="PRODUCTOS INGRESADOS" style="-fx-font-weight: bold; -fx-font-size: 14px; -fx-text-fill: white;"/>
-                <TableView fx:id="tablaProductos" VBox.vgrow="ALWAYS"
-                           style="
-                           -fx-text-background-color: #333333;
-                           -fx-background-color: rgba(255,255,255,0.9);
-                           -fx-table-cell-border-color: transparent;
-                           -fx-background-insets: 0;
-                           -fx-padding: 0;
-                           -fx-border-width: 0;
-                           -fx-table-header-border-color: transparent;
-                           -fx-background-radius: 15;">
+                <Label text="PRODUCTOS INGRESADOS"/>
+                <TableView fx:id="tablaProductos" VBox.vgrow="ALWAYS">
                     <columns>
-                        <TableColumn text="PRODUCTO" fx:id="colProducto" prefWidth="142" style="-fx-alignment: CENTER; -fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn text="PRODUCTO" fx:id="colProducto" prefWidth="142">
                             <cellValueFactory><PropertyValueFactory property="nombre"/></cellValueFactory>
                         </TableColumn>
-                        <TableColumn text="UNIDADES" fx:id="colUnidades" prefWidth="100" style="-fx-alignment: CENTER; -fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn text="UNIDADES" fx:id="colUnidades" prefWidth="100">
                             <cellValueFactory><PropertyValueFactory property="stock"/></cellValueFactory>
                         </TableColumn>
-                        <TableColumn text="PRECIO" fx:id="colPrecio" prefWidth="100" style="-fx-alignment: CENTER; -fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn text="PRECIO" fx:id="colPrecio" prefWidth="100">
                             <cellValueFactory><PropertyValueFactory property="precio"/></cellValueFactory>
                         </TableColumn>
                     </columns>
                 </TableView>
-                <HBox spacing="10" alignment="CENTER_RIGHT" style="-fx-padding: 10 0 0 0;">
-                    <Button text="Ingresar Producto" onAction="#handleIngresarProducto"
-                            style="-fx-background-color: linear-gradient(to right, #4CAF50, #2ECC71); -fx-text-fill: white; -fx-font-weight: bold; -fx-background-radius: 25;"/>
-                    <Button text="Editar" onAction="#handleEditarProducto"
-                            style="-fx-background-color: linear-gradient(to right, #FF9800, #F39C12); -fx-text-fill: white; -fx-font-weight: bold; -fx-background-radius: 25;"/>
-                    <Button text="Eliminar" onAction="#handleEliminarProducto"
-                            style="-fx-background-color: linear-gradient(to right, #e67e22, #e74c3c); -fx-text-fill: white; -fx-font-weight: bold; -fx-background-radius: 25;"/>
+                <HBox spacing="10" alignment="CENTER_RIGHT">
+                    <Button text="Ingresar Producto" onAction="#handleIngresarProducto"/>
+                    <Button text="Editar" onAction="#handleEditarProducto"/>
+                    <Button text="Eliminar" onAction="#handleEliminarProducto"/>
                 </HBox>
             </VBox>
 
             <!-- CARRITO DE VENTA -->
-            <VBox style="-fx-background-color: rgba(227,242,253,0.2); -fx-padding: 15; -fx-border-color: rgba(187,222,251,0.5); -fx-border-width: 1; -fx-border-radius: 15; -fx-background-radius: 15"
+            <VBox
                   spacing="10" GridPane.rowIndex="1" GridPane.columnIndex="1" VBox.vgrow="ALWAYS">
-                <Label text="CARRITO DE VENTA" style="-fx-font-weight: bold; -fx-font-size: 14px; -fx-text-fill: white;"/>
-                <TableView fx:id="tablaCarrito" prefHeight="200" VBox.vgrow="ALWAYS"
-                           style="
-                           -fx-text-background-color: #333333;
-                           -fx-background-color: rgba(255,255,255,0.9);
-                           -fx-table-cell-border-color: transparent;
-                           -fx-background-insets: 0;
-                           -fx-padding: 0;
-                           -fx-border-width: 0;
-                           -fx-table-header-border-color: transparent;
-                           -fx-background-radius: 15;">
+                <Label text="CARRITO DE VENTA"/>
+                <TableView fx:id="tablaCarrito" prefHeight="200" VBox.vgrow="ALWAYS">
                     <columns>
-                        <TableColumn fx:id="colCarritoNombre" text="PRODUCTO" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn fx:id="colCarritoNombre" text="PRODUCTO">
                             <cellValueFactory><PropertyValueFactory property="nombreProducto"/></cellValueFactory>
                         </TableColumn>
-                        <TableColumn fx:id="colCarritoUnidades" text="UNIDADES" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn fx:id="colCarritoUnidades" text="UNIDADES">
                             <cellValueFactory><PropertyValueFactory property="unidades"/></cellValueFactory>
                         </TableColumn>
-                        <TableColumn fx:id="colCarritoPrecio" text="PRECIO" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn fx:id="colCarritoPrecio" text="PRECIO">
                             <cellValueFactory><PropertyValueFactory property="precioUnitario"/></cellValueFactory>
                         </TableColumn>
-                        <TableColumn fx:id="colCarritoTotal" text="TOTAL" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn fx:id="colCarritoTotal" text="TOTAL">
                             <cellValueFactory><PropertyValueFactory property="total"/></cellValueFactory>
                         </TableColumn>
                     </columns>
                 </TableView>
                 <HBox alignment="CENTER_RIGHT" spacing="10">
                     <padding><Insets top="10" right="10" bottom="10" left="10"/></padding>
-                    <Label text="TOTAL:" style="-fx-font-size: 16px; -fx-font-weight: bold; -fx-text-fill: white;"/>
-                    <Label fx:id="lblTotalCarrito" text="" style="-fx-font-size: 16px; -fx-font-weight: bold; -fx-text-fill: white;"/>
+                    <Label text="TOTAL:"/>
+                    <Label fx:id="lblTotalCarrito" text=""/>
                 </HBox>
-                <Button text="Confirmar Venta" onAction="#handleConfirmarVenta"
-                        style="-fx-background-color: linear-gradient(to right, #2196F3, #3498db); -fx-text-fill: white; -fx-font-weight: bold; -fx-background-radius: 25;"/>
+                <Button text="Confirmar Venta" onAction="#handleConfirmarVenta"/>
             </VBox>
         </GridPane>
     </center>

--- a/src/main/resources/fxml/lista_clientes.fxml
+++ b/src/main/resources/fxml/lista_clientes.fxml
@@ -10,54 +10,28 @@
       xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="controllers.ListaClientesController"
       spacing="20"
-      style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e); -fx-padding: 25;"
-      prefWidth="850" prefHeight="650">
-    <HBox alignment="CENTER" spacing="15" style="-fx-padding: 0 0 20 0;">
-        <Label fx:id="lblTitulo" text="Gestión de Clientes"
-               style="-fx-font-size: 24px; -fx-font-weight: bold; -fx-text-fill: white;"/>
+      prefWidth="850" prefHeight="650" stylesheets="@../css/dashboard.css">
+    <HBox alignment="CENTER" spacing="15">
+        <Label fx:id="lblTitulo" text="Gestión de Clientes"/>
     </HBox>
-    <HBox spacing="10" style="-fx-padding: 0 0 20 0;" alignment="CENTER">
+    <HBox spacing="10" alignment="CENTER">
         <TextField fx:id="txtBuscar"
-                   style="-fx-pref-width: 450px; -fx-font-size: 14px; -fx-padding: 10px 15px;
-                          -fx-background-radius: 20px; -fx-border-radius: 20px; -fx-border-color: rgba(255,255,255,0.3);
-                          -fx-background-color: rgba(255,255,255,0.1); -fx-text-fill: white;"
                    promptText="Buscar por nombre, teléfono..."/>
-        <Button fx:id="btnLimpiar" text="Limpiar" onAction="#limpiarFiltro"
-                style="-fx-background-color: #6C757D; -fx-text-fill: white; -fx-font-weight: bold;
-                       -fx-padding: 8px 15px; -fx-background-radius: 20px; -fx-border-radius: 20px;
-                       -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 5, 0, 0, 2);"/>
+        <Button fx:id="btnLimpiar" text="Limpiar" onAction="#limpiarFiltro"/>
     </HBox>
-    <TableView fx:id="tablaClientes"
-               style="-fx-background-radius: 15px; -fx-background-insets: 0; -fx-padding: 0; -fx-alignment: CENTER;
-                      -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 1px;
-                      -fx-background-color: rgba(255,255,255,0.1); -fx-table-cell-border-color: rgba(255,255,255,0.2);">
+    <TableView fx:id="tablaClientes">
         <columns>
             <TableColumn text="Cliente" fx:id="colNombreCompleto"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;
-                                -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 0 1px 0 0;"
                          prefWidth="340"/>
             <TableColumn text="Teléfono" fx:id="colTelefono"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;
-                                -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 0 1px 0 0;"
                          prefWidth="210"/>
             <TableColumn text="Estado" fx:id="colEstado"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;
-                                -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 0 1px 0 0;"
                          prefWidth="170"/>
-            <TableColumn text="Acciones" fx:id="colAcciones"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;" prefWidth="130"/>
+            <TableColumn text="Acciones" fx:id="colAcciones" prefWidth="130"/>
         </columns>
     </TableView>
-    <HBox spacing="20" alignment="CENTER" style="-fx-padding: 20 0 0 0;">
-        <Button text="Volver al Dashboard" onAction="#handleVolver"
-                style="-fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF); -fx-text-fill: white;
-                       -fx-font-weight: bold; -fx-min-width: 220; -fx-font-size: 16px; -fx-padding: 10px 25px;
-                       -fx-background-radius: 25px; -fx-border-radius: 25px; -fx-cursor: hand;
-                       -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
-        <Button text="Ver Clientes Inactivos" onAction="#handleVerInactivos"
-                style="-fx-background-color: linear-gradient(to right, #e67e22, #e74c3c); -fx-text-fill: white;
-                       -fx-font-weight: bold; -fx-min-width: 220; -fx-font-size: 16px; -fx-padding: 10px 25px;
-                       -fx-background-radius: 25px; -fx-border-radius: 25px; -fx-cursor: hand;
-                       -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
+    <HBox spacing="20" alignment="CENTER">
+        <Button text="Volver al Dashboard" onAction="#handleVolver"/>
+        <Button text="Ver Clientes Inactivos" onAction="#handleVerInactivos"/>
     </HBox>
 </VBox>

--- a/src/main/resources/fxml/lista_clientes_inactivos.fxml
+++ b/src/main/resources/fxml/lista_clientes_inactivos.fxml
@@ -11,44 +11,22 @@
       fx:controller="controllers.ListaClientesInactivosController"
       spacing="20"
       alignment="CENTER"
-      style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e); -fx-padding: 25;"
-      prefWidth="850" prefHeight="650">
+      prefWidth="850" prefHeight="650" stylesheets="@../css/dashboard.css">
     <Label fx:id="lblTitulo" text="Clientes Inactivos"
-           style="-fx-font-size: 24px; -fx-font-weight: bold; -fx-text-fill: #4A6CF7; -fx-padding: 0 0 15px 0;"
            alignment="CENTER"/>
-    <HBox spacing="10" alignment="CENTER" style="-fx-padding: 0 0 20 0;">
-        <TextField fx:id="txtBuscar" promptText="Buscar cliente..."
-                   style="-fx-pref-width: 450px; -fx-font-size: 14px; -fx-padding: 10px 15px;
-                          -fx-background-radius: 20px; -fx-border-radius: 20px; -fx-border-color: rgba(255,255,255,0.3);
-                          -fx-background-color: rgba(255,255,255,0.1); -fx-text-fill: white;"/>
-        <Button fx:id="btnLimpiar" text="Limpiar" onAction="#limpiarFiltro"
-                style="-fx-background-color: #6C757D; -fx-text-fill: white; -fx-font-weight: bold;
-                       -fx-padding: 8px 15px; -fx-background-radius: 20px; -fx-border-radius: 20px;
-                       -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 5, 0, 0, 2);"/>
+    <HBox spacing="10" alignment="CENTER">
+        <TextField fx:id="txtBuscar" promptText="Buscar cliente..."/>
+        <Button fx:id="btnLimpiar" text="Limpiar" onAction="#limpiarFiltro"/>
     </HBox>
-    <TableView fx:id="tablaClientes"
-               style="-fx-background-radius: 15px; -fx-border-color: rgba(255,255,255,0.2);
-                      -fx-border-width: 1px; -fx-background-color: rgba(255,255,255,0.1);
-                      -fx-table-cell-border-color: rgba(255,255,255,0.2);">
+    <TableView fx:id="tablaClientes">
         <columns>
-            <TableColumn fx:id="colNombreCompleto" text="Cliente" prefWidth="340"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;
-                                -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 0 1px 0 0;"/>
-            <TableColumn fx:id="colTelefono" text="Teléfono" prefWidth="210"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;
-                                -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 0 1px 0 0;"/>
-            <TableColumn fx:id="colEstado" text="Estado" prefWidth="170"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;
-                                -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 0 1px 0 0;"/>
-            <TableColumn fx:id="colAcciones" text="Acciones" prefWidth="130"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;"/>
+            <TableColumn fx:id="colNombreCompleto" text="Cliente" prefWidth="340"/>
+            <TableColumn fx:id="colTelefono" text="Teléfono" prefWidth="210"/>
+            <TableColumn fx:id="colEstado" text="Estado" prefWidth="170"/>
+            <TableColumn fx:id="colAcciones" text="Acciones" prefWidth="130"/>
         </columns>
     </TableView>
-    <HBox spacing="10" alignment="CENTER" style="-fx-padding: 20 0 0 0;">
-        <Button text="Volver a Activos" onAction="#handleVolver"
-                style="-fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF); -fx-text-fill: white;
-                       -fx-font-weight: bold; -fx-min-width: 220; -fx-font-size: 16px; -fx-padding: 10px 25px;
-                       -fx-background-radius: 25px; -fx-border-radius: 25px;
-                       -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
+    <HBox spacing="10" alignment="CENTER">
+        <Button text="Volver a Activos" onAction="#handleVolver"/>
     </HBox>
 </VBox>

--- a/src/main/resources/fxml/lista_coaches.fxml
+++ b/src/main/resources/fxml/lista_coaches.fxml
@@ -10,34 +10,25 @@
       xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="controllers.ListaCoachesController"
       spacing="20"
-      style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e); -fx-padding: 25;"
-      prefWidth="850" prefHeight="650">
-    <HBox alignment="CENTER" spacing="15" style="-fx-padding: 0 0 20 0;">
-        <Label text="Gestión de Coaches"
-               style="-fx-font-size: 24px; -fx-font-weight: bold; -fx-text-fill: white;"/>
+      prefWidth="850" prefHeight="650" stylesheets="@../css/dashboard.css">
+    <HBox alignment="CENTER" spacing="15">
+        <Label text="Gestión de Coaches"/>
     </HBox>
-    <HBox spacing="10" style="-fx-padding: 0 0 20 0;" alignment="CENTER">
+    <HBox spacing="10" alignment="CENTER">
         <TextField fx:id="txtBuscar"
-                style="-fx-pref-width: 450px; -fx-font-size: 14px; -fx-padding: 10px 15px; -fx-background-radius: 20px; -fx-border-radius: 20px; -fx-border-color: rgba(255,255,255,0.3); -fx-background-color: rgba(255,255,255,0.1); -fx-text-fill: white;"
                 promptText="Buscar por nombre, área..."/>
-        <Button fx:id="btnLimpiar" text="Limpiar" onAction="#limpiarFiltro"
-                style="-fx-background-color: #6C757D; -fx-text-fill: white; -fx-font-weight: bold; -fx-padding: 8px 15px; -fx-background-radius: 20px; -fx-border-radius: 20px; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 5, 0, 0, 2);"/>
+        <Button fx:id="btnLimpiar" text="Limpiar" onAction="#limpiarFiltro"/>
     </HBox>
-    <TableView fx:id="tablaCoaches"
-               style="-fx-background-radius: 15px; -fx-background-insets: 0; -fx-padding: 0; -fx-alignment: CENTER; -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 1px; -fx-background-color: rgba(255,255,255,0.1); -fx-table-cell-border-color: rgba(255,255,255,0.2);">
+    <TableView fx:id="tablaCoaches">
         <columns>
             <TableColumn text="Coach" fx:id="colNombre"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white; -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 0 1px 0 0;"
                          prefWidth="340"/>
             <TableColumn text="Área" fx:id="colArea"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white; -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 0 1px 0 0;"
                          prefWidth="210"/>
-            <TableColumn text="Acciones" fx:id="colAcciones"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;" prefWidth="170"/>
+            <TableColumn text="Acciones" fx:id="colAcciones" prefWidth="170"/>
         </columns>
     </TableView>
-    <HBox spacing="20" alignment="CENTER" style="-fx-padding: 20 0 0 0;">
-        <Button text="Volver al Registro" onAction="#volverRegistro"
-                style="-fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF); -fx-text-fill: white; -fx-font-weight: bold; -fx-min-width: 220; -fx-font-size: 16px; -fx-padding: 10px 25px; -fx-background-radius: 25px; -fx-border-radius: 25px; -fx-cursor: hand; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
+    <HBox spacing="20" alignment="CENTER">
+        <Button text="Volver al Registro" onAction="#volverRegistro"/>
     </HBox>
 </VBox>

--- a/src/main/resources/fxml/login.fxml
+++ b/src/main/resources/fxml/login.fxml
@@ -3,15 +3,15 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
-<AnchorPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controllers.LoginController" prefWidth="400" prefHeight="300" style="-fx-background-color: linear-gradient(to bottom, #1e3c72, #2a5298);">
+<AnchorPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controllers.LoginController" prefWidth="400" prefHeight="300" stylesheets="@../css/dashboard.css">
     <children>
         <VBox alignment="CENTER" spacing="10" AnchorPane.topAnchor="0" AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0" AnchorPane.rightAnchor="0">
-            <Label text="Iniciar Sesión" style="-fx-text-fill: white; -fx-font-size: 20;"/>
+            <Label text="Iniciar Sesión"/>
             <TextField fx:id="txtUsuario" promptText="Usuario" maxWidth="200"/>
             <PasswordField fx:id="txtPassword" promptText="Contraseña" maxWidth="200"/>
             <ChoiceBox fx:id="cbRol" maxWidth="200"/>
             <Button text="Ingresar" onAction="#handleLogin" maxWidth="200"/>
-            <Label fx:id="lblMensaje" style="-fx-text-fill: red;"/>
+            <Label fx:id="lblMensaje"/>
         </VBox>
     </children>
 </AnchorPane>

--- a/src/main/resources/fxml/perfil_coach.fxml
+++ b/src/main/resources/fxml/perfil_coach.fxml
@@ -11,35 +11,28 @@
       xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="controllers.PerfilCoachController"
       spacing="20"
-      style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e); -fx-padding: 25;"
-      prefWidth="850" prefHeight="650">
+      prefWidth="850" prefHeight="650" stylesheets="@../css/dashboard.css">
     <HBox spacing="20" alignment="CENTER">
         <ImageView fx:id="imgFoto" fitHeight="120" fitWidth="120" preserveRatio="true"/>
         <VBox spacing="10">
-            <Label fx:id="lblNombre" style="-fx-text-fill: white; -fx-font-size: 20px; -fx-font-weight: bold;"/>
-            <Label fx:id="lblArea" style="-fx-text-fill: white;"/>
-            <Label fx:id="lblTelefono" style="-fx-text-fill: white;"/>
+            <Label fx:id="lblNombre"/>
+            <Label fx:id="lblArea"/>
+            <Label fx:id="lblTelefono"/>
         </VBox>
     </HBox>
-    <HBox spacing="10" style="-fx-padding: 0 0 20 0;" alignment="CENTER">
+    <HBox spacing="10" alignment="CENTER">
         <TextField fx:id="txtBuscar"
-                style="-fx-pref-width: 450px; -fx-font-size: 14px; -fx-padding: 10px 15px; -fx-background-radius: 20px; -fx-border-radius: 20px; -fx-border-color: rgba(255,255,255,0.3); -fx-background-color: rgba(255,255,255,0.1); -fx-text-fill: white;"
                 promptText="Buscar cliente..."/>
-        <Button fx:id="btnLimpiar" text="Limpiar" onAction="#limpiarFiltro"
-                style="-fx-background-color: #6C757D; -fx-text-fill: white; -fx-font-weight: bold; -fx-padding: 8px 15px; -fx-background-radius: 20px; -fx-border-radius: 20px; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 5, 0, 0, 2);"/>
+        <Button fx:id="btnLimpiar" text="Limpiar" onAction="#limpiarFiltro"/>
     </HBox>
     <TableView fx:id="tablaClientes"
-               style="-fx-background-radius: 15px; -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 1px; -fx-background-color: rgba(255,255,255,0.1); -fx-table-cell-border-color: rgba(255,255,255,0.2);"
                prefHeight="300">
         <columns>
-            <TableColumn fx:id="colCliente" text="Cliente" prefWidth="340"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white; -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 0 1px 0 0;"/>
-            <TableColumn fx:id="colTelefono" text="Teléfono" prefWidth="210"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;"/>
+            <TableColumn fx:id="colCliente" text="Cliente" prefWidth="340"/>
+            <TableColumn fx:id="colTelefono" text="Teléfono" prefWidth="210"/>
         </columns>
     </TableView>
-    <HBox alignment="CENTER" style="-fx-padding: 20 0 0 0;">
-        <Button text="Cerrar" onAction="#handleCerrar"
-                style="-fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF); -fx-text-fill: white; -fx-font-weight: bold; -fx-min-width: 220; -fx-font-size: 16px; -fx-padding: 10px 25px; -fx-background-radius: 25px; -fx-border-radius: 25px; -fx-cursor: hand; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
+    <HBox alignment="CENTER">
+        <Button text="Cerrar" onAction="#handleCerrar"/>
     </HBox>
 </VBox>

--- a/src/main/resources/fxml/registro_cliente.fxml
+++ b/src/main/resources/fxml/registro_cliente.fxml
@@ -9,47 +9,26 @@
             xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="controllers.RegistroClienteController"
             prefWidth="900"
-            prefHeight="600"
-            style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e);">
+            prefHeight="600" stylesheets="@../css/dashboard.css">
     <center>
-        <VBox alignment="TOP_CENTER" spacing="30" style="-fx-padding: 40;">
-            <Label text="Registro de Cliente"
-                   style="-fx-font-size: 32px; -fx-font-weight: bold; -fx-text-fill: #4A6CF7;
-                          -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 3, 0, 1, 1);"/>
-            <VBox spacing="25" maxWidth="600" style="-fx-background-color: rgba(255,255,255,0.1);
-                    -fx-background-radius: 15; -fx-padding: 40;
-                    -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 1; -fx-border-radius: 15;
-                    -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.2), 15, 0, 0, 4);">
+        <VBox alignment="TOP_CENTER" spacing="30">
+            <Label text="Registro de Cliente"/>
+            <VBox spacing="25" maxWidth="600">
                 <GridPane hgap="20" vgap="20">
                     <columnConstraints>
                         <ColumnConstraints halignment="RIGHT" minWidth="120"/>
                         <ColumnConstraints hgrow="ALWAYS"/>
                     </columnConstraints>
-                    <Label text="Nombres:" GridPane.rowIndex="0" GridPane.columnIndex="0"
-                           style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <TextField fx:id="txtNombres" GridPane.rowIndex="0" GridPane.columnIndex="1"
-                               style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da;
-                                      -fx-border-radius: 8; -fx-background-radius: 8; -fx-padding: 10;"/>
-                    <Label text="Apellidos:" GridPane.rowIndex="1" GridPane.columnIndex="0"
-                           style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <TextField fx:id="txtApellidos" GridPane.rowIndex="1" GridPane.columnIndex="1"
-                               style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da;
-                                      -fx-border-radius: 8; -fx-background-radius: 8; -fx-padding: 10;"/>
-                    <Label text="Teléfono:" GridPane.rowIndex="2" GridPane.columnIndex="0"
-                           style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <TextField fx:id="txtTelefono" GridPane.rowIndex="2" GridPane.columnIndex="1"
-                               style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da;
-                                      -fx-border-radius: 8; -fx-background-radius: 8; -fx-padding: 10;"/>
-                    <Label text="Fecha de Inicio:" GridPane.rowIndex="3" GridPane.columnIndex="0"
-                           style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <DatePicker fx:id="dpFechaInicio" GridPane.rowIndex="3" GridPane.columnIndex="1"
-                                style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da;
-                                       -fx-border-radius: 8; -fx-background-radius: 8;"/>
-                    <Label text="Membresía:" GridPane.rowIndex="4" GridPane.columnIndex="0"
-                           style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <ComboBox fx:id="cbMembresia" GridPane.rowIndex="4" GridPane.columnIndex="1"
-                              style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da;
-                                     -fx-border-radius: 8; -fx-background-radius: 8;" value="Diario">
+                    <Label text="Nombres:" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+                    <TextField fx:id="txtNombres" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+                    <Label text="Apellidos:" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+                    <TextField fx:id="txtApellidos" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
+                    <Label text="Teléfono:" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
+                    <TextField fx:id="txtTelefono" GridPane.rowIndex="2" GridPane.columnIndex="1"/>
+                    <Label text="Fecha de Inicio:" GridPane.rowIndex="3" GridPane.columnIndex="0"/>
+                    <DatePicker fx:id="dpFechaInicio" GridPane.rowIndex="3" GridPane.columnIndex="1"/>
+                    <Label text="Membresía:" GridPane.rowIndex="4" GridPane.columnIndex="0"/>
+                    <ComboBox fx:id="cbMembresia" GridPane.rowIndex="4" GridPane.columnIndex="1" value="Diario">
                         <items>
                             <FXCollections fx:factory="observableArrayList">
                                 <String fx:value="Diario"/>
@@ -60,38 +39,20 @@
                             </FXCollections>
                         </items>
                     </ComboBox>
-                    <Label text="Área:" GridPane.rowIndex="5" GridPane.columnIndex="0"
-                           style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <ComboBox fx:id="cbArea" GridPane.rowIndex="5" GridPane.columnIndex="1"
-                              style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da;
-                                     -fx-border-radius: 8; -fx-background-radius: 8;"/>
-                    <Label text="Coach:" GridPane.rowIndex="6" GridPane.columnIndex="0"
-                           style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <ComboBox fx:id="cbCoach" GridPane.rowIndex="6" GridPane.columnIndex="1"
-                              style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da;
-                                     -fx-border-radius: 8; -fx-background-radius: 8;"/>
-                    <Label text="Monto de Pago:" GridPane.rowIndex="7" GridPane.columnIndex="0"
-                           style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <TextField fx:id="txtMontoPago" promptText="Monto de Pago" GridPane.rowIndex="7" GridPane.columnIndex="1"
-                               style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da;
-                                      -fx-border-radius: 8; -fx-background-radius: 8; -fx-padding: 10;"/>
+                    <Label text="Área:" GridPane.rowIndex="5" GridPane.columnIndex="0"/>
+                    <ComboBox fx:id="cbArea" GridPane.rowIndex="5" GridPane.columnIndex="1"/>
+                    <Label text="Coach:" GridPane.rowIndex="6" GridPane.columnIndex="0"/>
+                    <ComboBox fx:id="cbCoach" GridPane.rowIndex="6" GridPane.columnIndex="1"/>
+                    <Label text="Monto de Pago:" GridPane.rowIndex="7" GridPane.columnIndex="0"/>
+                    <TextField fx:id="txtMontoPago" promptText="Monto de Pago" GridPane.rowIndex="7" GridPane.columnIndex="1"/>
                 </GridPane>
-                <HBox spacing="20" alignment="CENTER" style="-fx-padding: 20 0 0 0;">
-                    <Button fx:id="btnSiguiente" text="Siguiente" onAction="#handleSiguiente"
-                            style="-fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF);
-                                   -fx-text-fill: white; -fx-font-weight: bold; -fx-background-radius: 25;
-                                   -fx-padding: 10 30; -fx-font-size: 14px; -fx-cursor: hand;
-                                   -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
+                <HBox spacing="20" alignment="CENTER">
+                    <Button fx:id="btnSiguiente" text="Siguiente" onAction="#handleSiguiente"/>
                     <Button fx:id="btnVolverAlDashboard" text="Volver al Dashboard"
-                            onAction="#handleVolverAlDashboard"
-                            style="-fx-background-color: #6C757D; -fx-text-fill: white;
-                                   -fx-font-weight: bold; -fx-background-radius: 25;
-                                   -fx-padding: 10 30; -fx-font-size: 14px; -fx-cursor: hand;
-                                   -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
+                            onAction="#handleVolverAlDashboard"/>
                 </HBox>
             </VBox>
-            <Label text="Todos los campos son obligatorios"
-                   style="-fx-text-fill: #bdc3c7; -fx-font-size: 14px; -fx-font-style: italic;"/>
+            <Label text="Todos los campos son obligatorios"/>
         </VBox>
     </center>
 </BorderPane>

--- a/src/main/resources/fxml/registro_coach.fxml
+++ b/src/main/resources/fxml/registro_coach.fxml
@@ -6,36 +6,34 @@
 <BorderPane xmlns="http://javafx.com/javafx/17"
             xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="controllers.RegistroCoachController"
-            prefWidth="900" prefHeight="600"
-            style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e);">
+            prefWidth="900" prefHeight="600" stylesheets="@../css/dashboard.css">
     <center>
-        <VBox alignment="TOP_CENTER" spacing="30" style="-fx-padding: 40;">
-            <Label text="Registro de Coach"
-                   style="-fx-font-size: 32px; -fx-font-weight: bold; -fx-text-fill: #4A6CF7; -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 3, 0, 1, 1);"/>
-            <VBox spacing="20" maxWidth="700" style="-fx-background-color: rgba(255,255,255,0.1); -fx-background-radius: 15; -fx-padding: 40; -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 1; -fx-border-radius: 15; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.2), 15, 0, 0, 4);">
+        <VBox alignment="TOP_CENTER" spacing="30">
+            <Label text="Registro de Coach"/>
+            <VBox spacing="20" maxWidth="700">
                 <GridPane hgap="20" vgap="15">
                     <columnConstraints>
                         <ColumnConstraints halignment="RIGHT" minWidth="120"/>
                         <ColumnConstraints hgrow="ALWAYS"/>
                     </columnConstraints>
-                    <Label text="Nombres:" GridPane.rowIndex="0" GridPane.columnIndex="0" style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <TextField fx:id="txtNombres" GridPane.rowIndex="0" GridPane.columnIndex="1" style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da; -fx-border-radius: 8; -fx-background-radius: 8; -fx-padding: 10;"/>
-                    <Label text="Apellidos:" GridPane.rowIndex="1" GridPane.columnIndex="0" style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <TextField fx:id="txtApellidos" GridPane.rowIndex="1" GridPane.columnIndex="1" style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da; -fx-border-radius: 8; -fx-background-radius: 8; -fx-padding: 10;"/>
-                    <Label text="Teléfono:" GridPane.rowIndex="2" GridPane.columnIndex="0" style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <TextField fx:id="txtTelefono" GridPane.rowIndex="2" GridPane.columnIndex="1" style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da; -fx-border-radius: 8; -fx-background-radius: 8; -fx-padding: 10;"/>
-                    <Label text="Área:" GridPane.rowIndex="3" GridPane.columnIndex="0" style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <ComboBox fx:id="cbArea" GridPane.rowIndex="3" GridPane.columnIndex="1" style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da; -fx-border-radius: 8; -fx-background-radius: 8;"/>
-                    <Label text="Foto:" GridPane.rowIndex="4" GridPane.columnIndex="0" style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
+                    <Label text="Nombres:" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+                    <TextField fx:id="txtNombres" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+                    <Label text="Apellidos:" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+                    <TextField fx:id="txtApellidos" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
+                    <Label text="Teléfono:" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
+                    <TextField fx:id="txtTelefono" GridPane.rowIndex="2" GridPane.columnIndex="1"/>
+                    <Label text="Área:" GridPane.rowIndex="3" GridPane.columnIndex="0"/>
+                    <ComboBox fx:id="cbArea" GridPane.rowIndex="3" GridPane.columnIndex="1"/>
+                    <Label text="Foto:" GridPane.rowIndex="4" GridPane.columnIndex="0"/>
                     <HBox spacing="10" GridPane.rowIndex="4" GridPane.columnIndex="1">
                         <ImageView fx:id="imgFoto" fitHeight="80" fitWidth="80" preserveRatio="true"/>
-                        <Button text="Seleccionar" onAction="#seleccionarFoto" style="-fx-background-color: #6C757D; -fx-text-fill: white; -fx-font-weight: bold; -fx-background-radius: 8; -fx-padding: 8 15;"/>
+                        <Button text="Seleccionar" onAction="#seleccionarFoto"/>
                     </HBox>
                 </GridPane>
-                <HBox spacing="20" alignment="CENTER" style="-fx-padding: 20 0 0 0;">
-                    <Button fx:id="btnGuardar" text="Guardar" onAction="#guardarCoach" style="-fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF); -fx-text-fill: white; -fx-font-weight: bold; -fx-background-radius: 25; -fx-padding: 10 30; -fx-font-size: 14px; -fx-cursor: hand; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
-                    <Button text="Ver Lista de Coaches" onAction="#abrirListaCoaches" style="-fx-background-color: #17A2B8; -fx-text-fill: white; -fx-font-weight: bold; -fx-background-radius: 25; -fx-padding: 10 30; -fx-font-size: 14px; -fx-cursor: hand; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
-                    <Button fx:id="btnVolver" text="Volver al Dashboard" onAction="#volverDashboard" style="-fx-background-color: #6C757D; -fx-text-fill: white; -fx-font-weight: bold; -fx-background-radius: 25; -fx-padding: 10 30; -fx-font-size: 14px; -fx-cursor: hand; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
+                <HBox spacing="20" alignment="CENTER">
+                    <Button fx:id="btnGuardar" text="Guardar" onAction="#guardarCoach"/>
+                    <Button text="Ver Lista de Coaches" onAction="#abrirListaCoaches"/>
+                    <Button fx:id="btnVolver" text="Volver al Dashboard" onAction="#volverDashboard"/>
                 </HBox>
             </VBox>
         </VBox>

--- a/src/main/resources/fxml/registro_egreso.fxml
+++ b/src/main/resources/fxml/registro_egreso.fxml
@@ -6,16 +6,12 @@
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="controllers.RegistroEgresoController"
       spacing="20" alignment="CENTER"
-      style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e); -fx-padding: 30;"
-      prefWidth="450" prefHeight="450">
+      prefWidth="450" prefHeight="450" stylesheets="@../css/dashboard.css">
     <Label text="Registro de Egreso"
-           style="-fx-font-size: 24px; -fx-font-weight: bold; -fx-text-fill: white;"
            alignment="CENTER" maxWidth="Infinity">
         <padding><Insets bottom="20"/></padding>
     </Label>
-    <GridPane style="-fx-background-color: rgba(255,255,255,0.1); -fx-padding: 25; -fx-background-radius: 15;
-                     -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 1; -fx-border-radius: 15;
-                     -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.15), 10, 0, 0, 0);">
+    <GridPane>
         <columnConstraints>
             <ColumnConstraints percentWidth="30"/>
             <ColumnConstraints percentWidth="70"/>
@@ -23,28 +19,20 @@
         <padding><Insets top="10" bottom="10" left="10" right="10"/></padding>
         <hgap>15</hgap>
         <vgap>15</vgap>
-        <Label text="Categoría:" style="-fx-font-weight: bold; -fx-text-fill: white;"
+        <Label text="Categoría:"
                GridPane.rowIndex="0" GridPane.columnIndex="0"/>
-        <ComboBox fx:id="cbCategoria" GridPane.rowIndex="0" GridPane.columnIndex="1"
-                  style="-fx-font-size: 14px; -fx-pref-height: 35px; -fx-background-color: rgba(255,255,255,0.9);"/>
-        <Label text="Monto ($):" style="-fx-font-weight: bold; -fx-text-fill: white;"
+        <ComboBox fx:id="cbCategoria" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+        <Label text="Monto ($):"
                GridPane.rowIndex="1" GridPane.columnIndex="0"/>
-        <TextField fx:id="txtMonto" GridPane.rowIndex="1" GridPane.columnIndex="1"
-                   style="-fx-font-size: 14px; -fx-pref-height: 35px; -fx-background-color: rgba(255,255,255,0.9);"/>
-        <Label text="Descripción:" style="-fx-font-weight: bold; -fx-text-fill: white;"
+        <TextField fx:id="txtMonto" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
+        <Label text="Descripción:"
                GridPane.rowIndex="2" GridPane.columnIndex="0"/>
         <TextArea fx:id="txtDescripcion" GridPane.rowIndex="2" GridPane.columnIndex="1"
-                  style="-fx-font-size: 14px; -fx-background-color: rgba(255,255,255,0.9);"
                   prefRowCount="4"/>
         <HBox spacing="15" alignment="CENTER_RIGHT"
               GridPane.columnIndex="1" GridPane.rowIndex="3">
-            <Button fx:id="btnRegistrar" text="Registrar" onAction="#handleRegistrar"
-                    style="-fx-background-color: linear-gradient(to right, #4CAF50, #2ECC71);
-                           -fx-text-fill: white; -fx-font-weight: bold; -fx-padding: 8 20; -fx-background-radius: 25;
-                           -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 5, 0, 0, 2);"/>
-            <Button fx:id="btnCancelar" text="Cancelar" onAction="#handleCancelar"
-                    style="-fx-background-color: #6C757D; -fx-text-fill: white; -fx-padding: 8 20; -fx-background-radius: 25;
-                           -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 5, 0, 0, 2);"/>
+            <Button fx:id="btnRegistrar" text="Registrar" onAction="#handleRegistrar"/>
+            <Button fx:id="btnCancelar" text="Cancelar" onAction="#handleCancelar"/>
         </HBox>
     </GridPane>
 </VBox>

--- a/src/main/resources/fxml/renovacion.fxml
+++ b/src/main/resources/fxml/renovacion.fxml
@@ -6,10 +6,9 @@
 <?import javafx.scene.control.cell.PropertyValueFactory?>
 <BorderPane xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="controllers.RenovacionController"
-            prefWidth="800" prefHeight="600" style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e); -fx-padding: 15;">
+            prefWidth="800" prefHeight="600" stylesheets="@../css/dashboard.css">
     <top>
         <Label text="Renovación de Membresías"
-               style="-fx-font-size: 20px; -fx-font-weight: bold; -fx-text-fill: white; -fx-padding: 0 0 10 0;"
                alignment="CENTER" maxWidth="Infinity"/>
     </top>
     <center>
@@ -21,88 +20,56 @@
 
             <!-- TABLA CLIENTES -->
             <VBox GridPane.columnIndex="0">
-                <HBox alignment="CENTER" spacing="10" style="-fx-padding: 0 0 10 0;">
-                    <TextField fx:id="txtBuscar" promptText="Buscar cliente..."
-                               style="-fx-pref-width: 250px; -fx-font-size: 12px; -fx-background-color: rgba(255,255,255,0.9);"/>
-                    <Button text="Filtrar" onAction="#filtrarClientes"
-                            style="-fx-background-color: linear-gradient(to right, #2196F3, #3498db); -fx-text-fill: white;
-                                   -fx-font-weight: bold; -fx-padding: 5 10; -fx-background-radius: 25;"/>
-                    <Button text="Limpiar" onAction="#limpiarFiltro"
-                            style="-fx-background-color: #6C757D; -fx-text-fill: white;
-                                   -fx-font-weight: bold; -fx-padding: 5 10; -fx-background-radius: 25;"/>
+                <HBox alignment="CENTER" spacing="10">
+                    <TextField fx:id="txtBuscar" promptText="Buscar cliente..."/>
+                    <Button text="Filtrar" onAction="#filtrarClientes"/>
+                    <Button text="Limpiar" onAction="#limpiarFiltro"/>
                 </HBox>
-                <TableView fx:id="tablaClientes" prefHeight="300"
-                           style="
-                           -fx-text-background-color: #333333;
-                           -fx-control-inner-background: rgba(255,255,255,0.9);
-                           -fx-table-cell-border-color: transparent;
-                           -fx-background-insets: 0;
-                           -fx-padding: 0;
-                           -fx-background-radius: 15;
-                           -fx-border-radius: 15;
-                           -fx-border-width: 0;
-                           -fx-table-header-border-color: transparent;">
+                <TableView fx:id="tablaClientes" prefHeight="300">
                     <columns>
-                        <TableColumn text="Nombre" prefWidth="150" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn text="Nombre" prefWidth="150">
                             <cellValueFactory><PropertyValueFactory property="nombreCompleto"/></cellValueFactory>
                         </TableColumn>
-                        <TableColumn text="Teléfono" prefWidth="100" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn text="Teléfono" prefWidth="100">
                             <cellValueFactory><PropertyValueFactory property="telefono"/></cellValueFactory>
                         </TableColumn>
-                        <TableColumn text="Vence" prefWidth="80" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn text="Vence" prefWidth="80">
                             <cellValueFactory><PropertyValueFactory property="fecha_vencimiento"/></cellValueFactory>
                         </TableColumn>
-                        <TableColumn text="Días" prefWidth="50" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn text="Días" prefWidth="50">
                             <cellValueFactory><PropertyValueFactory property="diasRestantes"/></cellValueFactory>
                         </TableColumn>
                     </columns>
                 </TableView>
-                <HBox alignment="CENTER" spacing="10" style="-fx-padding: 10 0;">
-                    <Button text="&lt; Anterior" fx:id="btnAnterior" onAction="#paginaAnterior"
-                            style="-fx-padding: 5 10; -fx-background-radius: 25; -fx-background-color: #6C757D; -fx-text-fill: white;"/>
-                    <Label fx:id="lblPagina" text="Página 1 de 1" style="-fx-font-weight: bold; -fx-text-fill: white;"/>
-                    <Button text="Siguiente &gt;" fx:id="btnSiguiente" onAction="#paginaSiguiente"
-                            style="-fx-padding: 5 10; -fx-background-radius: 25; -fx-background-color: #6C757D; -fx-text-fill: white;"/>
+                <HBox alignment="CENTER" spacing="10">
+                    <Button text="&lt; Anterior" fx:id="btnAnterior" onAction="#paginaAnterior"/>
+                    <Label fx:id="lblPagina" text="Página 1 de 1"/>
+                    <Button text="Siguiente &gt;" fx:id="btnSiguiente" onAction="#paginaSiguiente"/>
                 </HBox>
             </VBox>
 
             <!-- PANEL DERECHO -->
-            <VBox fx:id="panelDerecho" GridPane.columnIndex="1" spacing="15"
-                  style="-fx-background-color: rgba(255,255,255,0.9); -fx-padding: 15; -fx-background-radius: 15;
-                         -fx-border-radius: 15; -fx-border-color: rgba(255,255,255,0.2);">
-                <Label fx:id="lblInfoCliente" style="-fx-font-weight: bold; -fx-wrap-text: true; -fx-min-height: 35;
-                         -fx-padding: 0 5 0; -fx-text-fill: #2c3e50;"/>
-                <Separator style="-fx-padding: 5 0; -fx-background-color: rgba(0,0,0,0.2);"/>
-                <Label text="Nueva Membresía:" style="-fx-font-weight: bold; -fx-text-fill: #2c3e50;"/>
-                <ComboBox fx:id="cbNuevaMembresia" prefWidth="150" style="-fx-background-color: rgba(255,255,255,0.9);"/>
-                <Label text="Fecha de Renovación:" style="-fx-font-weight: bold; -fx-text-fill: #2c3e50;"/>
-                <DatePicker fx:id="dpFechaRenovacion" style="-fx-background-color: rgba(255,255,255,0.9);"/>
-                <Label text="Monto:" style="-fx-font-weight: bold; -fx-text-fill: #2c3e50;"/>
-                <TextField fx:id="txtMonto" promptText="Ingrese el monto" style="-fx-background-color: rgba(255,255,255,0.9);"/>
-                <Button text="Renovar" onAction="#handleRenovar"
-                        style="-fx-background-color: linear-gradient(to right, #4CAF50, #2ECC71); -fx-text-fill: white;
-                               -fx-font-weight: bold; -fx-padding: 8 15; -fx-background-radius: 25;"/>
-                <Separator style="-fx-padding: 10 0; -fx-background-color: rgba(0,0,0,0.2);"/>
-                <Label text="Historial de Pagos" style="-fx-font-weight: bold; -fx-font-size: 14px; -fx-text-fill: #2c3e50;"/>
-                <TableView fx:id="tablaHistorial" prefHeight="150"
-                           style="
-                           -fx-text-background-color: #333333;
-                           -fx-control-inner-background: rgba(255,255,255,0.9);
-                           -fx-table-cell-border-color: transparent;
-                           -fx-background-insets: 0;
-                           -fx-padding: 0;
-                           -fx-background-radius: 15;
-                           -fx-border-radius: 15;
-                           -fx-border-width: 0;
-                           -fx-table-header-border-color: transparent;">
+            <VBox fx:id="panelDerecho" GridPane.columnIndex="1" spacing="15">
+                <Label fx:id="lblInfoCliente"/>
+                <Separator/>
+                <Label text="Nueva Membresía:"/>
+                <ComboBox fx:id="cbNuevaMembresia" prefWidth="150"/>
+                <Label text="Fecha de Renovación:"/>
+                <DatePicker fx:id="dpFechaRenovacion"/>
+                <Label text="Monto:"/>
+                <TextField fx:id="txtMonto" promptText="Ingrese el monto"/>
+                <Button text="Renovar" onAction="#handleRenovar"/>
+                <Separator/>
+                <Label text="Historial de Pagos"/>
+                <TableView fx:id="tablaHistorial" prefHeight="150">
                     <columns>
-                        <TableColumn text="Fecha" prefWidth="80" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn text="Fecha" prefWidth="80">
                             <cellValueFactory><PropertyValueFactory property="fechaPago"/></cellValueFactory>
                         </TableColumn>
-                        <TableColumn text="Membresía" prefWidth="100" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn text="Membresía" prefWidth="100">
                             <cellValueFactory><PropertyValueFactory property="tipoMembresia"/></cellValueFactory>
                         </TableColumn>
-                        <TableColumn text="Monto" prefWidth="70" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
+                        <TableColumn text="Monto" prefWidth="70">
                             <cellValueFactory><PropertyValueFactory property="monto"/></cellValueFactory>
                         </TableColumn>
                     </columns>

--- a/src/main/resources/fxml/splash.fxml
+++ b/src/main/resources/fxml/splash.fxml
@@ -11,16 +11,14 @@
 <StackPane fx:id="rootPane" xmlns="http://javafx.com/javafx/17"
            xmlns:fx="http://javafx.com/fxml/1"
            fx:controller="controllers.SplashController"
-           style="-fx-background-color: linear-gradient(to bottom, #1a2a6c, #b21f1f, #fdbb2d);"
-           prefWidth="900" prefHeight="650">
+           prefWidth="900" prefHeight="650" stylesheets="@../css/dashboard.css">
 
     <!-- Logo centrado -->
     <VBox alignment="CENTER" spacing="10">
         <ImageView fx:id="imgLogo" fitWidth="500" fitHeight="400"
                    preserveRatio="true" pickOnBounds="true"/>
 
-        <Text text="SOFTWARE DE GESTIÓN"
-              style="-fx-fill: white; -fx-font-weight: bold;">
+        <Text text="SOFTWARE DE GESTIÓN">
             <font>
                 <Font name="Arial" size="24"/>
             </font>
@@ -29,7 +27,6 @@
 
     <!-- Barra de progreso - SIN ESTILOS DINÁMICOS -->
     <ProgressBar fx:id="progressBar"
-                 style="-fx-accent: #4A6CF7; -fx-pref-width: 400; -fx-background-radius: 5px;"
                  StackPane.alignment="BOTTOM_CENTER">
         <StackPane.margin>
             <Insets bottom="50"/>

--- a/src/main/resources/fxml/toast.fxml
+++ b/src/main/resources/fxml/toast.fxml
@@ -9,12 +9,10 @@
 <StackPane xmlns="http://javafx.com/javafx/17"
            xmlns:fx="http://javafx.com/fxml/1"
            fx:id="toastContainer"
-           style="-fx-background-color: rgba(0,0,0,0.7); -fx-background-radius: 20;"
            prefWidth="300"
-           prefHeight="60">
+           prefHeight="60" stylesheets="@../css/dashboard.css">
     <HBox alignment="CENTER" spacing="10">
         <ImageView fx:id="imgIcon" fitWidth="25" fitHeight="25" />
-        <Label fx:id="lblMensaje"
-               style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;" />
+        <Label fx:id="lblMensaje" />
     </HBox>
 </StackPane>


### PR DESCRIPTION
## Summary
- Añade hoja de estilos global con paleta de colores, tipografía y clases reutilizables.
- Enlaza todos los FXML al nuevo CSS y elimina atributos de estilo en línea.

## Testing
- `mvn -q test` *(falló: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb24e69b2c8332ad95e438c1dc539b