### PR TITLE
Agregar check-in diario de clientes y centrar columna de teléfono

### DIFF
--- a/src/main/java/controllers/RecepcionistaDashboardController.java
+++ b/src/main/java/controllers/RecepcionistaDashboardController.java
@@ -45,6 +45,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
 import java.util.ResourceBundle;
+import java.util.Set;
 import java.util.function.Consumer;
 
 public class RecepcionistaDashboardController implements Initializable {
@@ -82,6 +83,7 @@ public class RecepcionistaDashboardController implements Initializable {
             return;
         }
 
+        DatabaseUtil.inicializarTablaCheckIns();
         actualizarTituloRecepcionista();
         try {
 
@@ -338,6 +340,16 @@ public class RecepcionistaDashboardController implements Initializable {
                     setGraphic(null);
                 } else {
                     lblNombre.setText(nombre);
+                    Cliente clienteAsociado = null;
+                    if (getIndex() >= 0 && getIndex() < getTableView().getItems().size()) {
+                        clienteAsociado = getTableView().getItems().get(getIndex());
+                    }
+                    lblNombre.getStyleClass().remove("client-present");
+                    if (clienteAsociado != null && clienteAsociado.isPresenteHoy()) {
+                        if (!lblNombre.getStyleClass().contains("client-present")) {
+                            lblNombre.getStyleClass().add("client-present");
+                        }
+                    }
                     setGraphic(lblNombre);
                 }
             }
@@ -353,8 +365,9 @@ public class RecepcionistaDashboardController implements Initializable {
                 iconoTelefono.setIconSize(13);
                 lblTelefono.getStyleClass().add("cell-primary-text");
                 contenedor.getStyleClass().add("phone-cell");
-                contenedor.setAlignment(Pos.CENTER_LEFT);
-                setAlignment(Pos.CENTER_LEFT);
+                contenedor.setAlignment(Pos.CENTER);
+                lblTelefono.setAlignment(Pos.CENTER);
+                setAlignment(Pos.CENTER);
                 setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
             }
 
@@ -464,6 +477,10 @@ public class RecepcionistaDashboardController implements Initializable {
         colAccion.setCellFactory(column -> new TableCell<Cliente, Void>() {
             private final Button btnReactivar = new Button();
             private final FontIcon iconoReactivar = new FontIcon(FontAwesomeSolid.REDO);
+            private final Button btnCheckIn = new Button();
+            private final FontIcon iconoCheckIn = new FontIcon(FontAwesomeSolid.CHECK);
+            private final Tooltip tooltipCheckIn = new Tooltip("Registrar ingreso");
+            private final HBox contenedor = new HBox(8, btnCheckIn, btnReactivar);
 
             {
                 iconoReactivar.setIconColor(Color.web("#22c55e"));
@@ -475,20 +492,56 @@ public class RecepcionistaDashboardController implements Initializable {
                 btnReactivar.setTooltip(new Tooltip("Reactivar cliente"));
 
                 btnReactivar.setOnAction(event -> {
-                    Cliente cliente = getTableView().getItems().get(getIndex());
+                    int index = getIndex();
+                    if (index < 0 || index >= getTableView().getItems().size()) {
+                        return;
+                    }
+                    Cliente cliente = getTableView().getItems().get(index);
                     abrirRenovacionConCliente(cliente);
                 });
 
+                iconoCheckIn.setIconSize(16);
+                iconoCheckIn.setIconColor(Color.web("#22c55e"));
+                btnCheckIn.setGraphic(iconoCheckIn);
+                btnCheckIn.getStyleClass().add("table-icon-button");
+                btnCheckIn.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+                btnCheckIn.setFocusTraversable(false);
+                btnCheckIn.setTooltip(tooltipCheckIn);
+                btnCheckIn.setOnAction(event -> {
+                    int index = getIndex();
+                    if (index < 0 || index >= getTableView().getItems().size()) {
+                        return;
+                    }
+                    Cliente cliente = getTableView().getItems().get(index);
+                    if (cliente == null || cliente.isPresenteHoy()) {
+                        return;
+                    }
+                    DatabaseUtil.registrarCheckInCliente(cliente.getTelefono());
+                    cliente.setPresenteHoy(true);
+                    getTableView().refresh();
+                });
+
+                contenedor.setAlignment(Pos.CENTER);
                 setAlignment(Pos.CENTER);
+            }
+
+            private void actualizarEstadoCheckIn(Cliente cliente) {
+                boolean presente = cliente != null && cliente.isPresenteHoy();
+                btnCheckIn.setDisable(presente);
+                iconoCheckIn.setIconColor(presente ? Color.web("#16a34a") : Color.web("#22c55e"));
+                btnCheckIn.setOpacity(presente ? 0.7 : 1.0);
+                tooltipCheckIn.setText(presente ? "Ingreso registrado hoy" : "Registrar ingreso");
             }
 
             @Override
             protected void updateItem(Void item, boolean empty) {
                 super.updateItem(item, empty);
-                if (empty) {
+                if (empty || getIndex() < 0 || getIndex() >= getTableView().getItems().size()) {
                     setGraphic(null);
                 } else {
-                    setGraphic(btnReactivar);
+                    Cliente cliente = getTableView().getItems().get(getIndex());
+                    actualizarEstadoCheckIn(cliente);
+                    setGraphic(contenedor);
                 }
             }
         });
@@ -580,6 +633,8 @@ public class RecepcionistaDashboardController implements Initializable {
                 "AND date(fecha_vencimiento) BETWEEN date('now') AND date('now', '+7 days') " +
                 "ORDER BY fecha_vencimiento";
 
+        Set<String> clientesPresentesHoy = DatabaseUtil.obtenerClientesCheckInHoy();
+
         try (Connection conn = DatabaseUtil.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql);
              ResultSet rs = stmt.executeQuery()) {
@@ -587,15 +642,20 @@ public class RecepcionistaDashboardController implements Initializable {
             boolean hayClientes = false;
             while (rs.next()) {
                 hayClientes = true;
+                String telefono = rs.getString("telefono");
+                String telefonoNormalizado = telefono != null ? telefono.trim() : null;
                 Cliente cliente = new Cliente(
                         rs.getString("nombres"),
                         rs.getString("apellidos"),
-                        rs.getString("telefono"),
+                        telefonoNormalizado,
                         rs.getString("tipoMembresia"),
                         LocalDate.parse(rs.getString("fecha_vencimiento"))
                 );
 
                 cliente.setDiasRestantes();
+                if (telefonoNormalizado != null && clientesPresentesHoy.contains(telefonoNormalizado)) {
+                    cliente.setPresenteHoy(true);
+                }
 
                 clientes.add(cliente);
             }

--- a/src/main/java/models/Cliente.java
+++ b/src/main/java/models/Cliente.java
@@ -1,6 +1,8 @@
 package models;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -15,6 +17,7 @@ public class Cliente {
     private final StringProperty fecha_vencimiento;
     private final StringProperty tipoMembresia;
     private final IntegerProperty diasRestantes = new SimpleIntegerProperty(0);
+    private final BooleanProperty presenteHoy = new SimpleBooleanProperty(false);
 
     public Cliente(String nombres, String apellidos, String telefono, String tipoMembresia, LocalDate fecha_vencimiento) {
         this.nombres = new SimpleStringProperty(nombres);
@@ -39,6 +42,7 @@ public class Cliente {
     public StringProperty fechaVencimientoProperty() { return fecha_vencimiento; }
     public StringProperty tipoMembresiaProperty() { return tipoMembresia; }
     public IntegerProperty diasRestantesProperty() { return diasRestantes; }
+    public BooleanProperty presenteHoyProperty() { return presenteHoy; }
 
     public String getNombres() { return nombres.get(); }
     public String getApellidos() { return apellidos.get(); }
@@ -46,6 +50,7 @@ public class Cliente {
     public String getTipoMembresia() { return tipoMembresia.get(); }
     public String getFecha_vencimiento() { return fecha_vencimiento.get(); }
     public int getDiasRestantes() { return diasRestantes.get(); }
+    public boolean isPresenteHoy() { return presenteHoy.get(); }
 
     public String getEstado() {
         if (fecha_vencimiento.get() == null || fecha_vencimiento.get().isEmpty())
@@ -88,6 +93,10 @@ public class Cliente {
 
     public void setDiasRestantes(int dias) {
         this.diasRestantes.set(dias);
+    }
+
+    public void setPresenteHoy(boolean presente) {
+        this.presenteHoy.set(presente);
     }
 
     public void setTipoMembresia(String tipo) {

--- a/src/main/java/util/DatabaseUtil.java
+++ b/src/main/java/util/DatabaseUtil.java
@@ -2439,4 +2439,71 @@ public class DatabaseUtil {
             return null;
         }
     }
+
+    public static void inicializarTablaCheckIns() {
+        String sql = "CREATE TABLE IF NOT EXISTS cliente_checkin (" +
+                "telefono TEXT PRIMARY KEY," +
+                "fecha TEXT NOT NULL)";
+
+        try (Connection conn = getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute(sql);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        limpiarCheckInsAntiguos();
+    }
+
+    public static void registrarCheckInCliente(String telefono) {
+        if (telefono == null || telefono.isBlank()) {
+            return;
+        }
+
+        inicializarTablaCheckIns();
+
+        String sql = "INSERT INTO cliente_checkin (telefono, fecha) VALUES (?, date('now')) " +
+                "ON CONFLICT(telefono) DO UPDATE SET fecha = excluded.fecha";
+
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, telefono.trim());
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static Set<String> obtenerClientesCheckInHoy() {
+        inicializarTablaCheckIns();
+
+        Set<String> clientes = new HashSet<>();
+        String sql = "SELECT telefono FROM cliente_checkin WHERE fecha = date('now')";
+
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                String telefono = rs.getString("telefono");
+                if (telefono != null && !telefono.isBlank()) {
+                    clientes.add(telefono.trim());
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        return clientes;
+    }
+
+    public static void limpiarCheckInsAntiguos() {
+        String sql = "DELETE FROM cliente_checkin WHERE fecha < date('now')";
+
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/main/resources/css/dashboard.css
+++ b/src/main/resources/css/dashboard.css
@@ -475,6 +475,10 @@
     -fx-letter-spacing: 0.2px;
 }
 
+.client-present {
+    -fx-text-fill: #4ade80;
+}
+
 .cell-primary-text {
     -fx-text-fill: #f8fafc;
     -fx-font-size: 13px;
@@ -488,7 +492,7 @@
 }
 
 .phone-cell {
-    -fx-alignment: CENTER_LEFT;
+    -fx-alignment: CENTER;
 }
 
 .phone-cell .ikonli-font-icon {


### PR DESCRIPTION
## Summary
- Agrega persistencia en base de datos para registrar los check-ins diarios de los clientes
- Actualiza el dashboard del recepcionista con un botón de check-in que marca los nombres en verde y centra la columna de teléfono
- Ajusta los estilos para soportar el nuevo estado de asistencia

## Testing
- mvn -q -DskipTests package *(falla: sin acceso al repositorio central)*

------
https://chatgpt.com/codex/tasks/task_e_68d974ff20ec832f8a0142ef31674c00