### PR TITLE
Alinear diseño de clientes inactivos con la lista activa

### DIFF
--- a/src/main/java/controllers/ListaClientesInactivosController.java
+++ b/src/main/java/controllers/ListaClientesInactivosController.java
@@ -6,6 +6,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
+import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
@@ -18,13 +19,13 @@ import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
-import org.kordamp.ikonli.fontawesome5.FontAwesomeSolid;
-import org.kordamp.ikonli.javafx.FontIcon;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.util.Duration;
 import models.Cliente;
+import org.kordamp.ikonli.fontawesome5.FontAwesomeSolid;
+import org.kordamp.ikonli.javafx.FontIcon;
 import util.DatabaseUtil;
 
 import java.io.IOException;
@@ -34,6 +35,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.Comparator;
+import java.util.Locale;
 
 public class ListaClientesInactivosController {
 
@@ -45,13 +47,19 @@ public class ListaClientesInactivosController {
     @FXML private TextField txtBuscar;
     @FXML private Button btnLimpiar;
     @FXML private Label lblTitulo;
+    @FXML private Label lblResumen;
 
-    private ObservableList<Cliente> clientesOriginales = FXCollections.observableArrayList();
+    private static final String[] AVATAR_COLORES = {
+            "#5B8DEF", "#FF8C42", "#34C759", "#FF6B6B", "#A55EEA", "#20CFC3"
+    };
+    private static final Locale LOCALE_ES = new Locale("es", "ES");
+
+    private final ObservableList<Cliente> clientesOriginales = FXCollections.observableArrayList();
     private String estiloOriginalTabla;
 
     @FXML
     public void initialize() {
-        configurarEstilos();
+        configurarEstilosGlobales();
         configurarColumnas();
         cargarClientes();
         configurarBusqueda();
@@ -60,12 +68,37 @@ public class ListaClientesInactivosController {
         configurarFilas();
 
         estiloOriginalTabla = tablaClientes.getStyle();
+        actualizarResumen();
     }
 
-    private void configurarEstilos() {
-        lblTitulo.setStyle("-fx-font-size: 24px; -fx-font-weight: bold; -fx-text-fill: #4A6CF7; -fx-padding: 0 0 15px 0;");
-        lblTitulo.setAlignment(Pos.CENTER);
-        tablaClientes.setStyle("-fx-font-size: 14px; -fx-background-color: #ffffff; -fx-border-radius: 10px; -fx-background-radius: 10px; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.1), 10, 0, 0, 0);");
+    private void configurarEstilosGlobales() {
+        lblTitulo.setStyle(
+                "-fx-font-size: 26px;" +
+                        "-fx-font-weight: bold;" +
+                        "-fx-text-fill: #f5f7ff;" +
+                        "-fx-padding: 0 0 6px 0;"
+        );
+
+        if (lblResumen != null) {
+            lblResumen.setStyle(
+                    "-fx-text-fill: rgba(255,255,255,0.78);" +
+                            "-fx-font-size: 14px;" +
+                            "-fx-font-weight: semi-bold;"
+            );
+        }
+
+        tablaClientes.setStyle(
+                "-fx-font-size: 14px;" +
+                        "-fx-background-color: rgba(255,255,255,0.12);" +
+                        "-fx-border-radius: 18px;" +
+                        "-fx-background-radius: 18px;" +
+                        "-fx-padding: 6px;" +
+                        "-fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.2), 18, 0, 0, 0);"
+        );
+
+        Label placeholder = new Label("No se encontraron clientes inactivos con los filtros aplicados.");
+        placeholder.setStyle("-fx-text-fill: rgba(255,255,255,0.7); -fx-font-size: 14px; -fx-padding: 20px;");
+        tablaClientes.setPlaceholder(placeholder);
     }
 
     private void configurarColumnas() {
@@ -73,52 +106,107 @@ public class ListaClientesInactivosController {
         colTelefono.setCellValueFactory(new PropertyValueFactory<>("telefono"));
         colEstado.setCellValueFactory(new PropertyValueFactory<>("estado"));
 
-        colNombreCompleto.setCellFactory(column -> new TableCell<Cliente, String>() {
-            @Override
-            protected void updateItem(String item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                    setGraphic(null);
-                } else {
-                    setText(item);
-                    setStyle("-fx-alignment: CENTER; "
-                            + "-fx-font-weight: bold; "
-                            + "-fx-text-fill: black; "
-                            + "-fx-background-color: transparent;");
-                }
-            }
-        });
-
-        colTelefono.setCellFactory(column -> new TableCell<Cliente, String>() {
-            @Override
-            protected void updateItem(String item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                    setGraphic(null);
-                } else {
-                    setText(item);
-                    setStyle("-fx-alignment: CENTER; "
-                            + "-fx-font-weight: bold; "
-                            + "-fx-text-fill: black; "
-                            + "-fx-background-color: transparent;");
-                }
-            }
-        });
-
-        colEstado.setCellFactory(column -> new TableCell<Cliente, String>() {
-            private final StackPane container = new StackPane();
-            private final Circle indicador = new Circle(5);
-            private final Label texto = new Label();
+        colNombreCompleto.setCellFactory(column -> new TableCell<>() {
+            private final Circle avatarCircle = new Circle(18);
+            private final Label iniciales = new Label();
+            private final StackPane avatar = new StackPane();
+            private final Label nombre = new Label();
+            private final Label detalle = new Label();
+            private final VBox textContainer = new VBox(nombre, detalle);
+            private final HBox content = new HBox(12, avatar, textContainer);
 
             {
-                container.setAlignment(Pos.CENTER);
-                HBox caja = new HBox(5, indicador, texto);
-                caja.setAlignment(Pos.CENTER);
-                container.getChildren().add(caja);
+                avatar.getChildren().addAll(avatarCircle, iniciales);
+                avatar.setPrefSize(36, 36);
+                avatarCircle.setSmooth(true);
+                iniciales.setTextFill(Color.WHITE);
+                iniciales.setFont(Font.font("Arial", FontWeight.BOLD, 13));
 
-                texto.setFont(Font.font("Arial", FontWeight.BOLD, 12));
+                textContainer.setAlignment(Pos.CENTER_LEFT);
+                textContainer.setSpacing(2);
+
+                nombre.setStyle("-fx-font-weight: bold; -fx-text-fill: #f0f4ff; -fx-font-size: 15px;");
+                detalle.setStyle("-fx-text-fill: rgba(255,255,255,0.7); -fx-font-size: 12px;");
+
+                content.setAlignment(Pos.CENTER_LEFT);
+                content.setPadding(new Insets(4, 0, 4, 0));
+            }
+
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+
+                if (empty || item == null) {
+                    setGraphic(null);
+                    setText(null);
+                    return;
+                }
+
+                Cliente cliente = getTableRow() != null ? getTableRow().getItem() : null;
+                String nombreCompleto = cliente != null ? cliente.getNombreCompleto() : item;
+                nombre.setText(nombreCompleto != null ? nombreCompleto : "");
+
+                String membresia = cliente != null ? cliente.getTipoMembresia() : "";
+                String fechaVencimiento = cliente != null ? cliente.getFecha_vencimiento() : "";
+                if (membresia == null || membresia.isBlank()) {
+                    detalle.setText(fechaVencimiento != null && !fechaVencimiento.isBlank()
+                            ? "Venció: " + fechaVencimiento
+                            : "Sin membresía asignada");
+                } else {
+                    String resumen = membresia.toUpperCase(LOCALE_ES);
+                    if (fechaVencimiento != null && !fechaVencimiento.isBlank()) {
+                        resumen += " • Venció: " + fechaVencimiento;
+                    }
+                    detalle.setText(resumen);
+                }
+
+                String inicial = nombreCompleto != null && !nombreCompleto.isBlank()
+                        ? nombreCompleto.substring(0, 1).toUpperCase(LOCALE_ES)
+                        : "?";
+                iniciales.setText(inicial);
+                avatarCircle.setFill(Color.web(obtenerColorAvatar(nombreCompleto)));
+
+                setGraphic(content);
+                setText(null);
+                setStyle("-fx-alignment: CENTER_LEFT;");
+            }
+        });
+
+        colTelefono.setCellFactory(column -> new TableCell<>() {
+            private final FontIcon iconoTelefono = new FontIcon(FontAwesomeSolid.PHONE);
+            private final Label telefono = new Label();
+            private final HBox content = new HBox(8, iconoTelefono, telefono);
+
+            {
+                iconoTelefono.setIconColor(Color.web("#70a1ff"));
+                iconoTelefono.setIconSize(16);
+                telefono.setStyle("-fx-text-fill: #f8f9ff; -fx-font-weight: semi-bold;");
+                content.setAlignment(Pos.CENTER);
+            }
+
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item == null) {
+                    setGraphic(null);
+                    setText(null);
+                } else {
+                    telefono.setText(formatearTelefono(item));
+                    setGraphic(content);
+                    setText(null);
+                    setStyle("-fx-alignment: CENTER;");
+                }
+            }
+        });
+
+        colEstado.setCellFactory(column -> new TableCell<>() {
+            private final Label estadoLabel = new Label();
+            private final HBox container = new HBox(estadoLabel);
+
+            {
+                estadoLabel.setPadding(new Insets(4, 14, 4, 14));
+                estadoLabel.setFont(Font.font("Arial", FontWeight.BOLD, 12));
+                container.setAlignment(Pos.CENTER);
             }
 
             @Override
@@ -126,13 +214,13 @@ public class ListaClientesInactivosController {
                 super.updateItem(estado, empty);
                 if (empty || estado == null) {
                     setGraphic(null);
+                    setText(null);
                 } else {
-                    texto.setText(estado);
-                    indicador.setFill(Color.web("#DC3545"));
-                    texto.setStyle("-fx-text-fill: #DC3545; -fx-font-weight: bold;");
+                    estadoLabel.setText(estado);
+                    estadoLabel.setStyle("-fx-background-color: rgba(220,53,69,0.22); -fx-text-fill: #ff6b6b; -fx-background-radius: 999; -fx-font-size: 12px;");
                     setGraphic(container);
-                    setStyle("-fx-alignment: CENTER; "
-                            + "-fx-background-color: transparent;");
+                    setText(null);
+                    setStyle("-fx-alignment: CENTER;");
                 }
             }
         });
@@ -140,51 +228,50 @@ public class ListaClientesInactivosController {
         colAcciones.setCellFactory(param -> new TableCell<>() {
             private final Button btnActivar = new Button();
             private final Button btnEliminar = new Button();
-            private final HBox container = new HBox(10, btnActivar, btnEliminar);
+            private final FontIcon iconoActivar = new FontIcon(FontAwesomeSolid.REDO);
+            private final FontIcon iconoEliminar = new FontIcon(FontAwesomeSolid.TRASH);
+            private final HBox container = new HBox(8, btnActivar, btnEliminar);
 
             {
-                container.setAlignment(Pos.CENTER);
-
-                FontIcon iconoActivar = new FontIcon(FontAwesomeSolid.REDO);
-                iconoActivar.setIconColor(Color.web("#28a745"));
+                iconoActivar.setIconColor(Color.web("#34C759"));
                 iconoActivar.setIconSize(18);
                 btnActivar.setGraphic(iconoActivar);
-
-                FontIcon iconoEliminar = new FontIcon(FontAwesomeSolid.TRASH);
-                iconoEliminar.setIconColor(Color.web("#dc3545"));
-                iconoEliminar.setIconSize(18);
-                btnEliminar.setGraphic(iconoEliminar);
-
-                String estiloBase = "-fx-background-color: transparent; -fx-cursor: hand;";
-                btnActivar.setStyle(estiloBase);
-                btnEliminar.setStyle(estiloBase);
+                btnActivar.setPadding(new Insets(6));
+                btnActivar.setStyle("-fx-background-color: transparent; -fx-cursor: hand; -fx-background-radius: 10px;");
+                btnActivar.setTooltip(new Tooltip("Reactivar cliente"));
 
                 btnActivar.setOnMouseEntered(e ->
-                        btnActivar.setStyle("-fx-background-color: #e0f0ff; " + estiloBase)
+                        btnActivar.setStyle("-fx-background-color: rgba(52,199,89,0.18); -fx-cursor: hand; -fx-background-radius: 10px;")
                 );
                 btnActivar.setOnMouseExited(e ->
-                        btnActivar.setStyle(estiloBase)
+                        btnActivar.setStyle("-fx-background-color: transparent; -fx-cursor: hand; -fx-background-radius: 10px;")
                 );
-
-                btnEliminar.setOnMouseEntered(e ->
-                        btnEliminar.setStyle("-fx-background-color: #ffe0e0; " + estiloBase)
-                );
-                btnEliminar.setOnMouseExited(e ->
-                        btnEliminar.setStyle(estiloBase)
-                );
-
-                btnActivar.setTooltip(new Tooltip("Reactivar cliente"));
-                btnEliminar.setTooltip(new Tooltip("Eliminar cliente permanentemente"));
 
                 btnActivar.setOnAction(event -> {
                     Cliente cliente = getTableView().getItems().get(getIndex());
                     activarCliente(cliente);
                 });
 
+                iconoEliminar.setIconColor(Color.web("#ff6b6b"));
+                iconoEliminar.setIconSize(18);
+                btnEliminar.setGraphic(iconoEliminar);
+                btnEliminar.setPadding(new Insets(6));
+                btnEliminar.setStyle("-fx-background-color: transparent; -fx-cursor: hand; -fx-background-radius: 10px;");
+                btnEliminar.setTooltip(new Tooltip("Eliminar cliente permanentemente"));
+
+                btnEliminar.setOnMouseEntered(e ->
+                        btnEliminar.setStyle("-fx-background-color: rgba(255,107,107,0.18); -fx-cursor: hand; -fx-background-radius: 10px;")
+                );
+                btnEliminar.setOnMouseExited(e ->
+                        btnEliminar.setStyle("-fx-background-color: transparent; -fx-cursor: hand; -fx-background-radius: 10px;")
+                );
+
                 btnEliminar.setOnAction(event -> {
                     Cliente cliente = getTableView().getItems().get(getIndex());
                     eliminarCliente(cliente);
                 });
+
+                container.setAlignment(Pos.CENTER);
             }
 
             @Override
@@ -222,6 +309,7 @@ public class ListaClientesInactivosController {
             clientesTemp.sort(Comparator.comparing(Cliente::getNombreCompleto, String.CASE_INSENSITIVE_ORDER));
             tablaClientes.getItems().setAll(clientesTemp);
             clientesOriginales.setAll(tablaClientes.getItems());
+            actualizarResumen();
         } catch (SQLException e) {
             mostrarAlerta("Error", "No se pudieron cargar clientes inactivos");
         }
@@ -319,25 +407,65 @@ public class ListaClientesInactivosController {
         tablaClientes.getItems().clear();
         cargarClientes();
         clientesOriginales.setAll(tablaClientes.getItems());
-        Platform.runLater(this::ajustarAnchoColumnas);
+        Platform.runLater(() -> {
+            ajustarAnchoColumnas();
+            actualizarResumen();
+        });
     }
 
     private void configurarBusqueda() {
-        txtBuscar.setPromptText("Buscar cliente...");
-        txtBuscar.setStyle("-fx-font-size: 14px; -fx-padding: 8px 15px; -fx-background-radius: 20px; -fx-border-radius: 20px; -fx-border-color: #ced4da; -fx-background-color: #ffffff;");
+        txtBuscar.setPromptText("Buscar por nombre, teléfono o membresía");
+        txtBuscar.setStyle(
+                "-fx-font-size: 14px;" +
+                        "-fx-padding: 10px 18px;" +
+                        "-fx-background-radius: 24px;" +
+                        "-fx-border-radius: 24px;" +
+                        "-fx-border-color: rgba(255,255,255,0.25);" +
+                        "-fx-border-width: 1px;" +
+                        "-fx-background-color: rgba(255,255,255,0.12);" +
+                        "-fx-text-fill: white;" +
+                        "-fx-prompt-text-fill: rgba(255,255,255,0.55);"
+        );
 
-        btnLimpiar.setStyle("-fx-background-color: #6C757D; -fx-text-fill: white; -fx-font-weight: bold; -fx-padding: 8px 15px; -fx-background-radius: 20px; -fx-border-radius: 20px; -fx-cursor: hand;");
-        btnLimpiar.setOnMouseEntered(e -> btnLimpiar.setStyle("-fx-background-color: #5a6268; -fx-text-fill: white; -fx-font-weight: bold; -fx-padding: 8px 15px; -fx-background-radius: 20px; -fx-border-radius: 20px; -fx-cursor: hand;"));
-        btnLimpiar.setOnMouseExited(e -> btnLimpiar.setStyle("-fx-background-color: #6C757D; -fx-text-fill: white; -fx-font-weight: bold; -fx-padding: 8px 15px; -fx-background-radius: 20px; -fx-border-radius: 20px; -fx-cursor: hand;"));
+        btnLimpiar.setStyle(
+                "-fx-background-color: rgba(255,255,255,0.14);" +
+                        "-fx-text-fill: #f5f7ff;" +
+                        "-fx-font-weight: bold;" +
+                        "-fx-padding: 8px 18px;" +
+                        "-fx-background-radius: 22px;" +
+                        "-fx-border-radius: 22px;" +
+                        "-fx-border-color: rgba(255,255,255,0.25);" +
+                        "-fx-border-width: 1px;" +
+                        "-fx-cursor: hand;"
+        );
+        btnLimpiar.setOnMouseEntered(e ->
+                btnLimpiar.setStyle(
+                        "-fx-background-color: rgba(255,255,255,0.28);" +
+                                "-fx-text-fill: #111320;" +
+                                "-fx-font-weight: bold;" +
+                                "-fx-padding: 8px 18px;" +
+                                "-fx-background-radius: 22px;" +
+                                "-fx-border-radius: 22px;" +
+                                "-fx-border-color: rgba(255,255,255,0.35);" +
+                                "-fx-border-width: 1px;" +
+                                "-fx-cursor: hand;"
+                )
+        );
+        btnLimpiar.setOnMouseExited(e ->
+                btnLimpiar.setStyle(
+                        "-fx-background-color: rgba(255,255,255,0.14);" +
+                                "-fx-text-fill: #f5f7ff;" +
+                                "-fx-font-weight: bold;" +
+                                "-fx-padding: 8px 18px;" +
+                                "-fx-background-radius: 22px;" +
+                                "-fx-border-radius: 22px;" +
+                                "-fx-border-color: rgba(255,255,255,0.25);" +
+                                "-fx-border-width: 1px;" +
+                                "-fx-cursor: hand;"
+                )
+        );
 
-        txtBuscar.textProperty().addListener((observable, oldValue, newValue) -> {
-            filtrarClientes();
-            Platform.runLater(() -> {
-                ajustarAnchoColumnas();
-                tablaClientes.refresh();
-                tablaClientes.requestLayout();
-            });
-        });
+        txtBuscar.textProperty().addListener((observable, oldValue, newValue) -> filtrarClientes());
     }
 
     private void filtrarClientes() {
@@ -360,6 +488,7 @@ public class ListaClientesInactivosController {
         tablaClientes.refresh();
         tablaClientes.requestLayout();
         ajustarAnchoColumnas();
+        actualizarResumen();
     }
 
     @FXML
@@ -379,11 +508,12 @@ public class ListaClientesInactivosController {
         tablaClientes.refresh();
         tablaClientes.requestLayout();
         ajustarAnchoColumnas();
+        actualizarResumen();
     }
 
     private void configurarFilas() {
         tablaClientes.setRowFactory(tv -> {
-            TableRow<Cliente> row = new TableRow<Cliente>() {
+            TableRow<Cliente> row = new TableRow<>() {
                 @Override
                 protected void updateItem(Cliente cliente, boolean empty) {
                     super.updateItem(cliente, empty);
@@ -394,23 +524,25 @@ public class ListaClientesInactivosController {
                         setStyle("");
                         setTooltip(null);
                     } else {
-                        // TOOLTIP ESTILO DASHBOARD
                         Tooltip tooltip = new Tooltip(cliente.getTooltipText());
                         tooltip.setStyle("-fx-font-size: 12px; -fx-font-weight: bold;");
                         setTooltip(tooltip);
 
+                        String baseColor = obtenerColorFila(getIndex());
+                        String estiloBase = "-fx-background-color: " + baseColor + "; " +
+                                "-fx-border-color: transparent; " +
+                                "-fx-border-width: 0 0 1px 0;";
+
                         if (isSelected()) {
-                            setStyle("-fx-background-color: #e6f2ff; "
-                                    + "-fx-border-color: #e0e0e0; "
-                                    + "-fx-border-width: 0 0 1px 0;");
+                            setStyle("-fx-background-color: rgba(255,99,132,0.25); " +
+                                    "-fx-border-color: transparent; " +
+                                    "-fx-border-width: 0 0 1px 0;");
                         } else if (isHover()) {
-                            setStyle("-fx-background-color: #e6f2ff; "
-                                    + "-fx-border-color: #e0e0e0; "
-                                    + "-fx-border-width: 0 0 1px 0;");
+                            setStyle("-fx-background-color: rgba(255,99,132,0.18); " +
+                                    "-fx-border-color: transparent; " +
+                                    "-fx-border-width: 0 0 1px 0;");
                         } else {
-                            setStyle("-fx-background-color: #ffffff; "
-                                    + "-fx-border-color: #e0e0e0; "
-                                    + "-fx-border-width: 0 0 1px 0;");
+                            setStyle(estiloBase);
                         }
                     }
                 }
@@ -418,31 +550,31 @@ public class ListaClientesInactivosController {
 
             row.selectedProperty().addListener((obs, wasSelected, isNowSelected) -> {
                 if (isNowSelected) {
-                    row.setStyle("-fx-background-color: #e6f2ff; "
-                            + "-fx-border-color: #e0e0e0; "
-                            + "-fx-border-width: 0 0 1px 0;");
+                    row.setStyle("-fx-background-color: rgba(255,99,132,0.25); " +
+                            "-fx-border-color: transparent; " +
+                            "-fx-border-width: 0 0 1px 0;");
                 } else {
                     if (row.isHover()) {
-                        row.setStyle("-fx-background-color: #e6f2ff; "
-                                + "-fx-border-color: #e0e0e0; "
-                                + "-fx-border-width: 0 0 1px 0;");
+                        row.setStyle("-fx-background-color: rgba(255,99,132,0.18); " +
+                                "-fx-border-color: transparent; " +
+                                "-fx-border-width: 0 0 1px 0;");
                     } else {
-                        row.setStyle("-fx-background-color: #ffffff; "
-                                + "-fx-border-color: #e0e0e0; "
-                                + "-fx-border-width: 0 0 1px 0;");
+                        row.setStyle("-fx-background-color: " + obtenerColorFila(row.getIndex()) + "; " +
+                                "-fx-border-color: transparent; " +
+                                "-fx-border-width: 0 0 1px 0;");
                     }
                 }
             });
 
             row.hoverProperty().addListener((obs, oldVal, isHovering) -> {
                 if (isHovering && !row.isSelected()) {
-                    row.setStyle("-fx-background-color: #e6f2ff; "
-                            + "-fx-border-color: #e0e0e0; "
-                            + "-fx-border-width: 0 0 1px 0;");
+                    row.setStyle("-fx-background-color: rgba(255,99,132,0.18); " +
+                            "-fx-border-color: transparent; " +
+                            "-fx-border-width: 0 0 1px 0;");
                 } else if (!row.isSelected()) {
-                    row.setStyle("-fx-background-color: #ffffff; "
-                            + "-fx-border-color: #e0e0e0; "
-                            + "-fx-border-width: 0 0 1px 0;");
+                    row.setStyle("-fx-background-color: " + obtenerColorFila(row.getIndex()) + "; " +
+                            "-fx-border-color: transparent; " +
+                            "-fx-border-width: 0 0 1px 0;");
                 }
             });
 
@@ -450,14 +582,41 @@ public class ListaClientesInactivosController {
         });
     }
 
+    private String obtenerColorFila(int index) {
+        if (index < 0) {
+            return "transparent";
+        }
+        return index % 2 == 0 ? "rgba(255,107,107,0.12)" : "rgba(255,255,255,0.04)";
+    }
+
+    private String obtenerColorAvatar(String nombre) {
+        if (nombre == null || nombre.isBlank()) {
+            return AVATAR_COLORES[0];
+        }
+        int index = Math.abs(nombre.hashCode()) % AVATAR_COLORES.length;
+        return AVATAR_COLORES[index];
+    }
+
+    private String formatearTelefono(String telefono) {
+        if (telefono == null || telefono.isBlank()) {
+            return "Sin teléfono";
+        }
+
+        String soloDigitos = telefono.replaceAll("[^0-9]", "");
+        if (!soloDigitos.isEmpty()) {
+            return soloDigitos;
+        }
+        return telefono.trim();
+    }
+
     private void ajustarAnchoColumnas() {
         Platform.runLater(() -> {
             double anchoTotal = tablaClientes.getWidth();
             if (anchoTotal > 0) {
-                colNombreCompleto.setPrefWidth(anchoTotal * 0.52);
-                colTelefono.setPrefWidth(anchoTotal * 0.15);
-                colEstado.setPrefWidth(anchoTotal * 0.15);
-                colAcciones.setPrefWidth(anchoTotal * 0.15);
+                colNombreCompleto.setPrefWidth(anchoTotal * 0.45);
+                colTelefono.setPrefWidth(anchoTotal * 0.20);
+                colEstado.setPrefWidth(anchoTotal * 0.18);
+                colAcciones.setPrefWidth(anchoTotal * 0.12);
                 tablaClientes.requestLayout();
             }
         });
@@ -465,10 +624,10 @@ public class ListaClientesInactivosController {
         tablaClientes.widthProperty().addListener((obs, oldVal, newVal) -> {
             if (newVal.doubleValue() > 0) {
                 double anchoTotal = newVal.doubleValue();
-                colNombreCompleto.setPrefWidth(anchoTotal * 0.40);
+                colNombreCompleto.setPrefWidth(anchoTotal * 0.45);
                 colTelefono.setPrefWidth(anchoTotal * 0.25);
-                colEstado.setPrefWidth(anchoTotal * 0.20);
-                colAcciones.setPrefWidth(anchoTotal * 0.15);
+                colEstado.setPrefWidth(anchoTotal * 0.18);
+                colAcciones.setPrefWidth(anchoTotal * 0.12);
                 tablaClientes.requestLayout();
             }
         });
@@ -487,7 +646,7 @@ public class ListaClientesInactivosController {
                 node.setManaged(false);
             }
             for (javafx.scene.Node node : tablaClientes.lookupAll(".scroll-pane")) {
-                if (node instanceof javafx.scene.control.ScrollPane) {
+                if (node instanceof ScrollPane) {
                     ((ScrollPane) node).setVbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
                     ((ScrollPane) node).setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
                 }
@@ -512,5 +671,20 @@ public class ListaClientesInactivosController {
         alert.setHeaderText(null);
         alert.setContentText(mensaje);
         alert.showAndWait();
+    }
+
+    private void actualizarResumen() {
+        if (lblResumen == null) {
+            return;
+        }
+
+        int totalInactivos = clientesOriginales.size();
+        int visibles = tablaClientes.getItems() != null ? tablaClientes.getItems().size() : 0;
+
+        if (visibles == totalInactivos) {
+            lblResumen.setText(String.format("Clientes inactivos: %d", totalInactivos));
+        } else {
+            lblResumen.setText(String.format("Clientes inactivos: %d • Mostrando: %d", totalInactivos, visibles));
+        }
     }
 }

--- a/src/main/resources/fxml/lista_clientes_inactivos.fxml
+++ b/src/main/resources/fxml/lista_clientes_inactivos.fxml
@@ -9,46 +9,38 @@
 <VBox xmlns="http://javafx.com/javafx/21"
       xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="controllers.ListaClientesInactivosController"
-      spacing="20"
-      alignment="CENTER"
-      style="-fx-background-color: linear-gradient(to bottom, #2c3e50, #1a1a2e); -fx-padding: 25;"
-      prefWidth="850" prefHeight="650">
-    <Label fx:id="lblTitulo" text="Clientes Inactivos"
-           style="-fx-font-size: 24px; -fx-font-weight: bold; -fx-text-fill: #4A6CF7; -fx-padding: 0 0 15px 0;"
-           alignment="CENTER"/>
-    <HBox spacing="10" alignment="CENTER" style="-fx-padding: 0 0 20 0;">
-        <TextField fx:id="txtBuscar" promptText="Buscar cliente..."
-                   style="-fx-pref-width: 450px; -fx-font-size: 14px; -fx-padding: 10px 15px;
-                          -fx-background-radius: 20px; -fx-border-radius: 20px; -fx-border-color: rgba(255,255,255,0.3);
-                          -fx-background-color: rgba(255,255,255,0.1); -fx-text-fill: white;"/>
-        <Button fx:id="btnLimpiar" text="Limpiar" onAction="#limpiarFiltro"
-                style="-fx-background-color: #6C757D; -fx-text-fill: white; -fx-font-weight: bold;
-                       -fx-padding: 8px 15px; -fx-background-radius: 20px; -fx-border-radius: 20px;
-                       -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 5, 0, 0, 2);"/>
+      spacing="22"
+      style="-fx-background-color: linear-gradient(to bottom, #1e1f2b, #111320); -fx-padding: 28;"
+      prefWidth="900" prefHeight="650">
+    <VBox alignment="CENTER" spacing="6">
+        <Label fx:id="lblTitulo" text="Clientes Inactivos"
+               style="-fx-font-size: 26px; -fx-font-weight: bold; -fx-text-fill: #f5f7ff;"/>
+        <Label fx:id="lblResumen" text="Clientes inactivos: 0"
+               style="-fx-text-fill: rgba(255,255,255,0.78); -fx-font-size: 14px;"/>
+    </VBox>
+    <HBox spacing="12" style="-fx-padding: 0 0 10 0;" alignment="CENTER">
+        <TextField fx:id="txtBuscar"
+                   style="-fx-pref-width: 450px; -fx-font-size: 14px; -fx-padding: 10px 18px;"
+                   promptText="Buscar por nombre, teléfono o membresía"/>
+        <Button fx:id="btnLimpiar" text="Limpiar" onAction="#limpiarFiltro"/>
     </HBox>
     <TableView fx:id="tablaClientes"
-               style="-fx-background-radius: 15px; -fx-border-color: rgba(255,255,255,0.2);
-                      -fx-border-width: 1px; -fx-background-color: rgba(255,255,255,0.1);
-                      -fx-table-cell-border-color: rgba(255,255,255,0.2);">
+               style="-fx-background-radius: 18px; -fx-background-insets: 0; -fx-padding: 6; -fx-alignment: CENTER;"
+               prefHeight="470">
         <columns>
-            <TableColumn fx:id="colNombreCompleto" text="Cliente" prefWidth="340"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;
-                                -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 0 1px 0 0;"/>
-            <TableColumn fx:id="colTelefono" text="Teléfono" prefWidth="210"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;
-                                -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 0 1px 0 0;"/>
-            <TableColumn fx:id="colEstado" text="Estado" prefWidth="170"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;
-                                -fx-border-color: rgba(255,255,255,0.2); -fx-border-width: 0 1px 0 0;"/>
-            <TableColumn fx:id="colAcciones" text="Acciones" prefWidth="130"
-                         style="-fx-alignment: CENTER; -fx-text-fill: white;"/>
+            <TableColumn text="Cliente" fx:id="colNombreCompleto"
+                         style="-fx-alignment: CENTER_LEFT;" prefWidth="340"/>
+            <TableColumn text="Teléfono" fx:id="colTelefono"
+                         style="-fx-alignment: CENTER;" prefWidth="230"/>
+            <TableColumn text="Estado" fx:id="colEstado"
+                         style="-fx-alignment: CENTER;" prefWidth="150"/>
+            <TableColumn text="Acciones" fx:id="colAcciones"
+                         style="-fx-alignment: CENTER;" prefWidth="120"/>
         </columns>
     </TableView>
-    <HBox spacing="10" alignment="CENTER" style="-fx-padding: 20 0 0 0;">
+    <HBox spacing="20" alignment="CENTER" style="-fx-padding: 12 0 0 0;">
         <Button text="Volver a Activos" onAction="#handleVolver"
-                style="-fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF); -fx-text-fill: white;
-                       -fx-font-weight: bold; -fx-min-width: 220; -fx-font-size: 16px; -fx-padding: 10px 25px;
-                       -fx-background-radius: 25px; -fx-border-radius: 25px;
-                       -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
+                style="-fx-background-color: linear-gradient(to right, #4A6CF7, #2E8BFF); -fx-text-fill: white;"
+                prefWidth="220"/>
     </HBox>
 </VBox>


### PR DESCRIPTION
## Summary
- Actualizar el controlador de clientes inactivos para reutilizar el estilo moderno de la lista de activos, incluyendo avatares, etiquetas y botones con efectos hover.
- Ajustar el FXML de la vista de clientes inactivos para replicar la estructura visual de la lista activa con título, resumen y tabla estilizada.

## Testing
- `mvn -q -DskipTests package` *(falla: repositorio central devuelve 403 por restricciones de red)*

------
https://chatgpt.com/codex/tasks/task_e_68d97a1a3a08832f90af93e79e9cc86d