### PR TITLE
Exclude daily clients from upcoming lists and allow placeholder phones

### DIFF
--- a/src/main/java/controllers/EditarClienteController.java
+++ b/src/main/java/controllers/EditarClienteController.java
@@ -75,7 +75,7 @@ public class EditarClienteController {
         this.cliente = cliente;
         txtNombres.setText(cliente.getNombres());
         txtApellidos.setText(cliente.getApellidos());
-        txtTelefono.setText(cliente.getTelefono());
+        txtTelefono.setText(cliente.getTelefonoVisible());
         configurarValidaciones();
     }
 
@@ -144,23 +144,28 @@ public class EditarClienteController {
 
         if (!valido) return;
 
+        String telefonoVisible = txtTelefono.getText().trim();
+        String telefonoInterno = generarTelefonoInterno(telefonoVisible, cliente.getTelefono());
+
         actualizarClienteEnBD(
                 txtNombres.getText().trim(),
                 txtApellidos.getText().trim(),
-                txtTelefono.getText().trim()
+                telefonoInterno,
+                telefonoVisible
         );
     }
 
-    private void actualizarClienteEnBD(String nombres, String apellidos, String telefono) {
-        String sql = "UPDATE clientes SET nombres = ?, apellidos = ?, telefono = ? WHERE telefono = ?";
+    private void actualizarClienteEnBD(String nombres, String apellidos, String telefonoInterno, String telefonoVisible) {
+        String sql = "UPDATE clientes SET nombres = ?, apellidos = ?, telefono = ?, telefono_visible = ? WHERE telefono = ?";
 
         try (Connection conn = DatabaseUtil.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
 
             stmt.setString(1, nombres);
             stmt.setString(2, apellidos);
-            stmt.setString(3, telefono);
-            stmt.setString(4, cliente.getTelefono());
+            stmt.setString(3, telefonoInterno);
+            stmt.setString(4, telefonoVisible);
+            stmt.setString(5, cliente.getTelefono());
 
             int filasAfectadas = stmt.executeUpdate();
             System.out.println("Filas afectadas: " + filasAfectadas); // Para depuración
@@ -198,4 +203,16 @@ public class EditarClienteController {
         Stage stage = (Stage) btnGuardar.getScene().getWindow();
         stage.close();
     }
+
+    private String generarTelefonoInterno(String telefonoVisible, String telefonoActual) {
+        String valor = telefonoVisible != null ? telefonoVisible.trim() : "";
+        if (valor.equals("0000000000")) {
+            if (telefonoActual != null && telefonoActual.startsWith("AUTO-")) {
+                return telefonoActual;
+            }
+            return "AUTO-" + System.currentTimeMillis();
+        }
+        return valor;
+    }
 }
+

--- a/src/main/java/controllers/ListaClientesController.java
+++ b/src/main/java/controllers/ListaClientesController.java
@@ -110,7 +110,7 @@ public class ListaClientesController implements Initializable {
 
     private void configurarColumnas() {
         colNombreCompleto.setCellValueFactory(new PropertyValueFactory<>("nombreCompleto"));
-        colTelefono.setCellValueFactory(new PropertyValueFactory<>("telefono"));
+        colTelefono.setCellValueFactory(new PropertyValueFactory<>("telefonoVisible"));
         colEstado.setCellValueFactory(new PropertyValueFactory<>("estado"));
 
         colNombreCompleto.setCellFactory(column -> new TableCell<>() {
@@ -611,7 +611,7 @@ public class ListaClientesController implements Initializable {
             ObservableList<Cliente> filtrados = FXCollections.observableArrayList();
             for (Cliente cliente : clientesOriginales) {
                 String nombre = cliente.getNombreCompleto().toLowerCase();
-                String telefono = cliente.getTelefono() != null ? cliente.getTelefono().toLowerCase() : "";
+                String telefono = cliente.getTelefonoVisible() != null ? cliente.getTelefonoVisible().toLowerCase() : "";
                 String telefonoNumerico = telefono.replaceAll("[^0-9]", "");
                 String membresia = cliente.getTipoMembresia() != null ? cliente.getTipoMembresia().toLowerCase() : "";
 
@@ -758,7 +758,8 @@ public class ListaClientesController implements Initializable {
     }
 
     private void cargarClientes() {
-        String sql = "SELECT nombres, apellidos, telefono, tipoMembresia, fecha_vencimiento FROM clientes WHERE activo = 1";
+        String sql = "SELECT nombres, apellidos, telefono, telefono_visible, tipoMembresia, fecha_vencimiento " +
+                "FROM clientes WHERE activo = 1";
 
         try (Connection conn = DatabaseUtil.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql);
@@ -771,6 +772,7 @@ public class ListaClientesController implements Initializable {
                         rs.getString("nombres"),
                         rs.getString("apellidos"),
                         rs.getString("telefono"),
+                        rs.getString("telefono_visible"),
                         rs.getString("tipoMembresia"),
                         LocalDate.parse(rs.getString("fecha_vencimiento"))
                 );

--- a/src/main/java/controllers/ListaClientesInactivosController.java
+++ b/src/main/java/controllers/ListaClientesInactivosController.java
@@ -103,7 +103,7 @@ public class ListaClientesInactivosController {
 
     private void configurarColumnas() {
         colNombreCompleto.setCellValueFactory(new PropertyValueFactory<>("nombreCompleto"));
-        colTelefono.setCellValueFactory(new PropertyValueFactory<>("telefono"));
+        colTelefono.setCellValueFactory(new PropertyValueFactory<>("telefonoVisible"));
         colEstado.setCellValueFactory(new PropertyValueFactory<>("estado"));
 
         colNombreCompleto.setCellFactory(column -> new TableCell<>() {
@@ -287,7 +287,8 @@ public class ListaClientesInactivosController {
     }
 
     private void cargarClientes() {
-        String sql = "SELECT nombres, apellidos, telefono, tipoMembresia, fecha_vencimiento FROM clientes WHERE activo = 0";
+        String sql = "SELECT nombres, apellidos, telefono, telefono_visible, tipoMembresia, fecha_vencimiento " +
+                "FROM clientes WHERE activo = 0";
 
         try (Connection conn = DatabaseUtil.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql);
@@ -300,6 +301,7 @@ public class ListaClientesInactivosController {
                         rs.getString("nombres"),
                         rs.getString("apellidos"),
                         rs.getString("telefono"),
+                        rs.getString("telefono_visible"),
                         rs.getString("tipoMembresia"),
                         LocalDate.parse(rs.getString("fecha_vencimiento"))
                 );
@@ -476,7 +478,7 @@ public class ListaClientesInactivosController {
         } else {
             ObservableList<Cliente> filtrados = FXCollections.observableArrayList();
             for (Cliente cliente : clientesOriginales) {
-                if (cliente.getNombreCompleto().toLowerCase().contains(filtro) || cliente.getTelefono().contains(filtro)) {
+                if (cliente.getNombreCompleto().toLowerCase().contains(filtro) || cliente.getTelefonoVisible().contains(filtro)) {
                     filtrados.add(cliente);
                 }
             }

--- a/src/main/java/controllers/PerfilCoachController.java
+++ b/src/main/java/controllers/PerfilCoachController.java
@@ -53,7 +53,7 @@ public class PerfilCoachController {
 
     private void configurarColumnas() {
         colCliente.setCellValueFactory(new PropertyValueFactory<>("nombreCompleto"));
-        colTelefono.setCellValueFactory(new PropertyValueFactory<>("telefono"));
+        colTelefono.setCellValueFactory(new PropertyValueFactory<>("telefonoVisible"));
 
         colCliente.setCellFactory(column -> new TableCell<Cliente, String>() {
             @Override
@@ -237,7 +237,7 @@ public class PerfilCoachController {
             ObservableList<Cliente> filtrados = FXCollections.observableArrayList();
             for (Cliente cliente : clientesOriginales) {
                 if (cliente.getNombreCompleto().toLowerCase().contains(filtro) ||
-                        cliente.getTelefono().contains(filtro)) {
+                        cliente.getTelefonoVisible().contains(filtro)) {
                     filtrados.add(cliente);
                 }
             }
@@ -276,7 +276,7 @@ public class PerfilCoachController {
 
     private void cargarClientes(int coachId) {
         tablaClientes.getItems().clear();
-        String sql = "SELECT nombres, apellidos, telefono, fecha_vencimiento FROM clientes WHERE coach_id = ?";
+        String sql = "SELECT nombres, apellidos, telefono, telefono_visible, fecha_vencimiento FROM clientes WHERE coach_id = ?";
         try (Connection conn = DatabaseUtil.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setInt(1, coachId);
@@ -286,6 +286,7 @@ public class PerfilCoachController {
                         rs.getString("nombres"),
                         rs.getString("apellidos"),
                         rs.getString("telefono"),
+                        rs.getString("telefono_visible"),
                         LocalDate.parse(rs.getString("fecha_vencimiento"))
                 ));
             }

--- a/src/main/java/controllers/RecepcionistaDashboardController.java
+++ b/src/main/java/controllers/RecepcionistaDashboardController.java
@@ -114,7 +114,7 @@ public class RecepcionistaDashboardController implements Initializable {
 
             colCliente.setCellValueFactory(new PropertyValueFactory<>("nombreCompleto"));
             colMembresia.setCellValueFactory(new PropertyValueFactory<>("tipoMembresia"));
-            colTelefono.setCellValueFactory(new PropertyValueFactory<>("telefono"));
+            colTelefono.setCellValueFactory(new PropertyValueFactory<>("telefonoVisible"));
             colVencimiento.setCellValueFactory(new PropertyValueFactory<>("fecha_vencimiento"));
             colDiasRestantes.setCellValueFactory(new PropertyValueFactory<>("diasRestantes"));
 
@@ -582,6 +582,7 @@ public class RecepcionistaDashboardController implements Initializable {
 
             String sqlVencimientos = "SELECT COUNT(*) AS total FROM clientes " +
                     "WHERE activo = 1 " +
+                    "AND LOWER(tipoMembresia) <> 'diario' " +
                     "AND date(fecha_vencimiento) BETWEEN date('now') AND date('now', '+7 days')";
             try (PreparedStatement ps = conn.prepareStatement(sqlVencimientos);
                  ResultSet rs = ps.executeQuery()) {
@@ -636,9 +637,10 @@ public class RecepcionistaDashboardController implements Initializable {
 
     private void cargarClientesProximosAVencer() {
         ObservableList<Cliente> clientes = FXCollections.observableArrayList();
-        String sql = "SELECT nombres, apellidos, telefono, tipoMembresia, fecha_vencimiento " +
+        String sql = "SELECT nombres, apellidos, telefono, telefono_visible, tipoMembresia, fecha_vencimiento " +
                 "FROM clientes " +
                 "WHERE activo = 1 " +
+                "AND LOWER(tipoMembresia) <> 'diario' " +
                 "AND date(fecha_vencimiento) BETWEEN date('now') AND date('now', '+7 days') " +
                 "ORDER BY fecha_vencimiento";
 
@@ -653,6 +655,7 @@ public class RecepcionistaDashboardController implements Initializable {
                         rs.getString("nombres"),
                         rs.getString("apellidos"),
                         rs.getString("telefono"),
+                        rs.getString("telefono_visible"),
                         rs.getString("tipoMembresia"),
                         LocalDate.parse(rs.getString("fecha_vencimiento"))
                 );

--- a/src/main/java/controllers/RegistroClienteController.java
+++ b/src/main/java/controllers/RegistroClienteController.java
@@ -151,7 +151,7 @@ public class RegistroClienteController {
         try (Connection conn = DatabaseUtil.getConnection()) {
             conn.setAutoCommit(false);
 
-            String sqlCliente = "INSERT INTO clientes (nombres, apellidos, telefono, tipoMembresia, fechaInicio, fecha_vencimiento, monto_pago, area, coach_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            String sqlCliente = "INSERT INTO clientes (nombres, apellidos, telefono, telefono_visible, tipoMembresia, fechaInicio, fecha_vencimiento, monto_pago, area, coach_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
             PreparedStatement stmtCliente = conn.prepareStatement(sqlCliente, PreparedStatement.RETURN_GENERATED_KEYS);
 
             String montoStr = validarCampo(txtMontoPago.getText(), "Monto de Pago");
@@ -164,32 +164,39 @@ public class RegistroClienteController {
             LocalDate fechaInicio = diario ? LocalDate.now() : dpFechaInicio.getValue();
             LocalDate fechaVencimiento = diario ? fechaInicio : calcularVencimiento(fechaInicio, cbMembresia.getValue());
 
+            String telefonoInterno;
+            String telefonoVisible;
             if (diario) {
                 stmtCliente.setString(1, "CLIENTE");
                 stmtCliente.setString(2, "DIARIO");
                 String telefono = String.valueOf(System.currentTimeMillis());
                 telefono = telefono.substring(telefono.length() - 10);
-                stmtCliente.setString(3, telefono);
+                telefonoInterno = telefono;
+                telefonoVisible = telefono;
             } else {
                 stmtCliente.setString(1, validarCampo(txtNombres.getText(), "Nombres"));
                 stmtCliente.setString(2, validarCampo(txtApellidos.getText(), "Apellidos"));
-                stmtCliente.setString(3, validarCampo(txtTelefono.getText(), "Teléfono"));
+                telefonoVisible = validarCampo(txtTelefono.getText(), "Teléfono");
+                telefonoInterno = generarTelefonoInterno(telefonoVisible, null);
             }
 
-            stmtCliente.setString(4, cbMembresia.getValue());
-            stmtCliente.setString(5, fechaInicio.toString());
-            stmtCliente.setString(6, fechaVencimiento.toString());
-            stmtCliente.setDouble(7, monto);
+            stmtCliente.setString(3, telefonoInterno);
+            stmtCliente.setString(4, telefonoVisible);
+
+            stmtCliente.setString(5, cbMembresia.getValue());
+            stmtCliente.setString(6, fechaInicio.toString());
+            stmtCliente.setString(7, fechaVencimiento.toString());
+            stmtCliente.setDouble(8, monto);
 
             if (diario) {
-                stmtCliente.setNull(8, java.sql.Types.VARCHAR);
-                stmtCliente.setNull(9, java.sql.Types.INTEGER);
+                stmtCliente.setNull(9, java.sql.Types.VARCHAR);
+                stmtCliente.setNull(10, java.sql.Types.INTEGER);
             } else {
-                stmtCliente.setString(8, cbArea.getValue());
+                stmtCliente.setString(9, cbArea.getValue());
                 if (cbCoach.getValue() != null) {
-                    stmtCliente.setInt(9, cbCoach.getValue().getId());
+                    stmtCliente.setInt(10, cbCoach.getValue().getId());
                 } else {
-                    stmtCliente.setNull(9, java.sql.Types.INTEGER);
+                    stmtCliente.setNull(10, java.sql.Types.INTEGER);
                 }
             }
 
@@ -242,7 +249,8 @@ public class RegistroClienteController {
                 Cliente nuevoCliente = new Cliente(
                         txtNombres.getText().trim(),
                         txtApellidos.getText().trim(),
-                        txtTelefono.getText().trim(),
+                        telefonoInterno,
+                        telefonoVisible,
                         cbMembresia.getValue(),
                         fechaVencimiento
                 );
@@ -329,6 +337,17 @@ public class RegistroClienteController {
             case "1 Año" -> fechaInicio.plusYears(1);
             default -> fechaInicio;
         };
+    }
+
+    private String generarTelefonoInterno(String telefonoVisible, String telefonoActual) {
+        String valor = telefonoVisible != null ? telefonoVisible.trim() : "";
+        if (valor.equals("0000000000")) {
+            if (telefonoActual != null && telefonoActual.startsWith("AUTO-")) {
+                return telefonoActual;
+            }
+            return "AUTO-" + System.currentTimeMillis();
+        }
+        return valor;
     }
 
     private String validarCampo(String valor, String nombreCampo) {

--- a/src/main/java/controllers/RenovacionController.java
+++ b/src/main/java/controllers/RenovacionController.java
@@ -160,9 +160,10 @@ public class RenovacionController {
     }
 
     private void cargarClientesProximos() {
-        String sql = "SELECT nombres, apellidos, telefono, tipoMembresia, fecha_vencimiento " +
+        String sql = "SELECT nombres, apellidos, telefono, telefono_visible, tipoMembresia, fecha_vencimiento " +
                 "FROM clientes " +
                 "WHERE activo = 1 " +
+                "AND LOWER(tipoMembresia) <> 'diario' " +
                 "AND date(fecha_vencimiento) >= date('now', '-15 days') " +  // Incluye período de gracia
                 "AND date(fecha_vencimiento) <= date('now', '+7 days') " +   // Hasta 7 días en futuro
                 "ORDER BY fecha_vencimiento ASC";
@@ -171,7 +172,7 @@ public class RenovacionController {
     }
 
     private void cargarTodosClientesActivos() {
-        String sql = "SELECT nombres, apellidos, telefono, tipoMembresia, fecha_vencimiento " +
+        String sql = "SELECT nombres, apellidos, telefono, telefono_visible, tipoMembresia, fecha_vencimiento " +
                 "FROM clientes WHERE activo = 1";
 
         cargarClientesDesdeSQL(sql, todosClientes);
@@ -191,6 +192,7 @@ public class RenovacionController {
                         rs.getString("nombres"),
                         rs.getString("apellidos"),
                         rs.getString("telefono"),
+                        rs.getString("telefono_visible"),
                         rs.getString("tipoMembresia"),
                         fechaVencimiento
                 );
@@ -226,7 +228,7 @@ public class RenovacionController {
         List<Cliente> filtrados = todosClientes.stream()
                 .filter(cliente ->
                         (cliente.getNombres() + " " + cliente.getApellidos()).toLowerCase().contains(filtro) ||
-                                cliente.getTelefono().contains(filtro)
+                                cliente.getTelefonoVisible().contains(filtro)
                 )
                 .collect(Collectors.toList());
 
@@ -409,6 +411,7 @@ public class RenovacionController {
                         seleccionado.getNombres(),
                         seleccionado.getApellidos(),
                         seleccionado.getTelefono(),
+                        seleccionado.getTelefonoVisible(),
                         cbNuevaMembresia.getValue(),
                         nuevaFecha
                 );

--- a/src/main/java/models/Cliente.java
+++ b/src/main/java/models/Cliente.java
@@ -14,31 +14,40 @@ public class Cliente {
     private final StringProperty nombres;
     private final StringProperty apellidos;
     private final StringProperty telefono;
+    private final StringProperty telefonoVisible;
     private final StringProperty fecha_vencimiento;
     private final StringProperty tipoMembresia;
     private final BooleanProperty asistioHoy = new SimpleBooleanProperty(false);
     private final IntegerProperty diasRestantes = new SimpleIntegerProperty(0);
 
-    public Cliente(String nombres, String apellidos, String telefono, String tipoMembresia, LocalDate fecha_vencimiento) {
+    public Cliente(String nombres, String apellidos, String telefono, String telefonoVisible, String tipoMembresia, LocalDate fecha_vencimiento) {
         this.nombres = new SimpleStringProperty(nombres);
         this.apellidos = new SimpleStringProperty(apellidos);
         this.telefono = new SimpleStringProperty(telefono);
+        this.telefonoVisible = new SimpleStringProperty(
+                telefonoVisible != null && !telefonoVisible.isBlank() ? telefonoVisible : telefono
+        );
         this.tipoMembresia = new SimpleStringProperty(tipoMembresia);
         this.fecha_vencimiento = new SimpleStringProperty(fecha_vencimiento.toString());
         setDiasRestantes();
     }
 
+    public Cliente(String nombres, String apellidos, String telefono, String telefonoVisible, LocalDate fecha_vencimiento) {
+        this(nombres, apellidos, telefono, telefonoVisible, "No definido", fecha_vencimiento);
+    }
+
     public Cliente(String nombres, String apellidos, String telefono, LocalDate fecha_vencimiento) {
-        this(nombres, apellidos, telefono, "No definido", fecha_vencimiento);
+        this(nombres, apellidos, telefono, telefono, "No definido", fecha_vencimiento);
     }
 
     public Cliente(String nombres, String telefono, LocalDate fecha_vencimiento) {
-        this(nombres, "", telefono, "No definido", fecha_vencimiento);
+        this(nombres, "", telefono, telefono, "No definido", fecha_vencimiento);
     }
 
     public StringProperty nombresProperty() { return nombres; }
     public StringProperty apellidosProperty() { return apellidos; }
     public StringProperty telefonoProperty() { return telefono; }
+    public StringProperty telefonoVisibleProperty() { return telefonoVisible; }
     public StringProperty fechaVencimientoProperty() { return fecha_vencimiento; }
     public StringProperty tipoMembresiaProperty() { return tipoMembresia; }
     public IntegerProperty diasRestantesProperty() { return diasRestantes; }
@@ -47,6 +56,7 @@ public class Cliente {
     public String getNombres() { return nombres.get(); }
     public String getApellidos() { return apellidos.get(); }
     public String getTelefono() { return telefono.get(); }
+    public String getTelefonoVisible() { return telefonoVisible.get(); }
     public String getTipoMembresia() { return tipoMembresia.get(); }
     public String getFecha_vencimiento() { return fecha_vencimiento.get(); }
     public int getDiasRestantes() { return diasRestantes.get(); }
@@ -127,9 +137,16 @@ public class Cliente {
         }
 
         return "Nombre: " + getNombres() + " " + getApellidos() + "\n" +
-                "Teléfono: " + getTelefono() + "\n" +
+                "Teléfono: " + getTelefonoVisible() + "\n" +
                 "Membresía: " + getTipoMembresia() + "\n" +
                 "Vence: " + getFecha_vencimiento() + "\n" +
                 infoDias;
     }
+
+    public void setTelefonoVisible(String telefonoVisible) {
+        this.telefonoVisible.set(
+                telefonoVisible != null && !telefonoVisible.isBlank() ? telefonoVisible : this.telefono.get()
+        );
+    }
 }
+

--- a/src/main/java/util/DatabaseUtil.java
+++ b/src/main/java/util/DatabaseUtil.java
@@ -53,6 +53,7 @@ public class DatabaseUtil {
                 "nombres TEXT NOT NULL," +
                 "apellidos TEXT NOT NULL," +
                 "telefono TEXT NOT NULL UNIQUE," +
+                "telefono_visible TEXT NOT NULL DEFAULT ''," +
                 "tipoMembresia TEXT NOT NULL," +
                 "fechaInicio TEXT NOT NULL," +
                 "fecha_vencimiento TEXT NOT NULL," +
@@ -226,6 +227,8 @@ public class DatabaseUtil {
             stmt.execute(sqlAuditoriaUsuarios);
             stmt.execute(sqlProveedores);
             stmt.execute(sqlProveedorProductos);
+            try { stmt.execute("ALTER TABLE clientes ADD COLUMN telefono_visible TEXT NOT NULL DEFAULT ''"); } catch (SQLException ignored) {}
+            try { stmt.execute("UPDATE clientes SET telefono_visible = telefono WHERE telefono_visible IS NULL OR telefono_visible = ''"); } catch (SQLException ignored) {}
             try { stmt.execute("ALTER TABLE clientes ADD COLUMN area TEXT"); } catch (SQLException ignored) {}
             try { stmt.execute("ALTER TABLE clientes ADD COLUMN coach_id INTEGER REFERENCES coaches(id)"); } catch (SQLException ignored) {}
             try { stmt.execute("ALTER TABLE productos ADD COLUMN stock_inicial INTEGER DEFAULT 0"); } catch (SQLException ignored) {}
@@ -748,7 +751,7 @@ public class DatabaseUtil {
         SELECT 
             (SELECT COUNT(*) FROM clientes WHERE activo = 1) AS clientes_activos,
             (SELECT COUNT(*) FROM pagos WHERE date(fecha_pago) = CURRENT_DATE AND estado = 'ACTIVO') AS pagos_hoy,
-            (SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento BETWEEN CURRENT_DATE AND date('now', '+7 days')) AS por_vencer
+            (SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento BETWEEN CURRENT_DATE AND date('now', '+7 days') AND LOWER(tipoMembresia) <> 'diario') AS por_vencer
         """;
 
         try (Connection conn = getConnection();
@@ -771,7 +774,7 @@ public class DatabaseUtil {
             (SELECT COUNT(*) FROM clientes WHERE activo = 1) AS clientes_activos,
             (SELECT COUNT(*) FROM clientes WHERE activo = 0) AS clientes_inactivos,
             (SELECT COUNT(*) FROM pagos WHERE strftime('%Y-%m', fecha_pago) = strftime('%Y-%m','now') AND estado = 'ACTIVO') AS membresias_mes,
-            (SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento BETWEEN date('now') AND date('now', '+7 day')) AS por_vencer,
+            (SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento BETWEEN date('now') AND date('now', '+7 day') AND LOWER(tipoMembresia) <> 'diario') AS por_vencer,
             (SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento < date('now') AND activo = 1) AS clientes_morosos,
             (SELECT COALESCE(MAX(cantidad),0) FROM (SELECT COUNT(*) AS cantidad FROM clientes WHERE coach_id IS NOT NULL GROUP BY coach_id)) AS coaches_top,
             (SELECT COUNT(*) FROM clientes WHERE activo = 1 AND date(fecha_inicio) <= date('now') AND date(fecha_vencimiento) >= date('now')) AS activos_hoy

--- a/src/main/java/util/EstadoClienteService.java
+++ b/src/main/java/util/EstadoClienteService.java
@@ -31,8 +31,9 @@ public class EstadoClienteService {
 
     public static List<Cliente> obtenerClientesPorVencerEn(int dias) {
         List<Cliente> clientes = new ArrayList<>();
-        String sql = "SELECT nombres, apellidos, telefono, tipoMembresia, fecha_vencimiento " +
+        String sql = "SELECT nombres, apellidos, telefono, telefono_visible, tipoMembresia, fecha_vencimiento " +
                 "FROM clientes WHERE fecha_vencimiento = ? AND activo = 1 " +
+                "AND LOWER(tipoMembresia) <> 'diario' " +
                 "AND telefono NOT IN (SELECT telefono_cliente FROM alertas_enviadas WHERE fecha_envio = CURRENT_DATE AND tipo_alerta = 'Vencimiento')";
         LocalDate objetivo = LocalDate.now().plusDays(dias);
         try (Connection conn = DatabaseUtil.getConnection();
@@ -44,6 +45,7 @@ public class EstadoClienteService {
                             rs.getString("nombres"),
                             rs.getString("apellidos"),
                             rs.getString("telefono"),
+                            rs.getString("telefono_visible"),
                             LocalDate.parse(rs.getString("fecha_vencimiento"))
                     );
                     c.setTipoMembresia(rs.getString("tipoMembresia"));

--- a/src/main/java/util/ReporteUtil.java
+++ b/src/main/java/util/ReporteUtil.java
@@ -530,8 +530,9 @@ public class ReporteUtil {
                 return;
             }
 
-            String sql = "SELECT nombres, apellidos, telefono, fecha_vencimiento AS fechaVencimiento " +
+            String sql = "SELECT nombres, apellidos, telefono_visible AS telefono, fecha_vencimiento AS fechaVencimiento " +
                     "FROM clientes WHERE activo = 1 " +
+                    "AND LOWER(tipoMembresia) <> 'diario' " +
                     "AND date(fecha_vencimiento) BETWEEN date('now') AND date('now','+7 day') " +
                     "ORDER BY fecha_vencimiento";
 

--- a/src/main/java/util/WhatsAppService.java
+++ b/src/main/java/util/WhatsAppService.java
@@ -56,6 +56,11 @@ public class WhatsAppService {
                         return;
                 }
 
+                if (cliente.getTelefonoVisible() == null || cliente.getTelefonoVisible().isBlank() || cliente.getTelefonoVisible().matches("0{10}")) {
+                        System.out.println(LocalDateTime.now() + " - Cliente sin número válido, se omite envío.");
+                        return;
+                }
+
                 try {
                         if (driver == null || !esDriverActivo()) {
                                 iniciarDriver();

--- a/src/main/resources/fxml/renovacion.fxml
+++ b/src/main/resources/fxml/renovacion.fxml
@@ -47,7 +47,7 @@
                             <cellValueFactory><PropertyValueFactory property="nombreCompleto"/></cellValueFactory>
                         </TableColumn>
                         <TableColumn text="Teléfono" prefWidth="100" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
-                            <cellValueFactory><PropertyValueFactory property="telefono"/></cellValueFactory>
+                            <cellValueFactory><PropertyValueFactory property="telefonoVisible"/></cellValueFactory>
                         </TableColumn>
                         <TableColumn text="Vence" prefWidth="80" style="-fx-text-fill: #2c3e50; -fx-border-width: 0;">
                             <cellValueFactory><PropertyValueFactory property="fecha_vencimiento"/></cellValueFactory>


### PR DESCRIPTION
## Summary
- add a visible phone column to the client schema and update registration/editing flows to accept "0000000000" while storing a unique internal value
- omit "Diario" memberships from upcoming renewal queries, dashboard metrics, and the renewal report
- skip WhatsApp alerts for clients without a real phone number

## Testing
- `mvn -q -DskipTests compile` *(fails: Maven Central returns 403 for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d99c63c960832f9d14349a64ebfa97