### PR TITLE
Exclude daily clients from expiring list and allow phone-optional registration

### DIFF
--- a/src/main/java/controllers/RecepcionistaDashboardController.java
+++ b/src/main/java/controllers/RecepcionistaDashboardController.java
@@ -639,6 +639,7 @@ public class RecepcionistaDashboardController implements Initializable {
         String sql = "SELECT nombres, apellidos, telefono, tipoMembresia, fecha_vencimiento " +
                 "FROM clientes " +
                 "WHERE activo = 1 " +
+                "AND (tipoMembresia IS NULL OR LOWER(tipoMembresia) <> 'diario') " +
                 "AND date(fecha_vencimiento) BETWEEN date('now') AND date('now', '+7 days') " +
                 "ORDER BY fecha_vencimiento";
 

--- a/src/main/java/controllers/RegistroClienteController.java
+++ b/src/main/java/controllers/RegistroClienteController.java
@@ -36,6 +36,7 @@ public class RegistroClienteController {
     @FXML private ComboBox<Coach> cbCoach;
     @FXML private Button btnSiguiente;
     @FXML private Button btnVolverAlDashboard;
+    @FXML private CheckBox chkSinTelefono;
 
     private final ObservableList<Coach> coaches = FXCollections.observableArrayList();
 
@@ -49,6 +50,17 @@ public class RegistroClienteController {
         }
 
         ajustarCamposPorMembresia(cbMembresia.getValue());
+
+        if (chkSinTelefono != null) {
+            chkSinTelefono.selectedProperty().addListener((obs, oldVal, newVal) -> {
+                if (!"Diario".equals(cbMembresia.getValue())) {
+                    actualizarEstadoTelefono(newVal);
+                }
+            });
+            if (!"Diario".equals(cbMembresia.getValue())) {
+                actualizarEstadoTelefono(chkSinTelefono.isSelected());
+            }
+        }
 
         if (cbArea != null) {
             cbArea.getItems().addAll("Maquinas", "Bailoterapia", "Crossfit");
@@ -114,9 +126,21 @@ public class RegistroClienteController {
             txtApellidos.setDisable(diario);
             if (diario) txtApellidos.clear();
         }
+        if (chkSinTelefono != null) {
+            chkSinTelefono.setDisable(diario);
+            if (diario) {
+                chkSinTelefono.setSelected(false);
+            }
+        }
         if (txtTelefono != null) {
-            txtTelefono.setDisable(diario);
-            if (diario) txtTelefono.clear();
+            if (diario) {
+                txtTelefono.clear();
+            }
+            boolean sinTelefono = diario || (chkSinTelefono != null && chkSinTelefono.isSelected());
+            actualizarEstadoTelefono(sinTelefono);
+            if (diario) {
+                txtTelefono.setPromptText(null);
+            }
         }
         if (dpFechaInicio != null) {
             dpFechaInicio.setDisable(diario);
@@ -142,6 +166,8 @@ public class RegistroClienteController {
         }
 
         boolean diario = "Diario".equals(cbMembresia.getValue());
+
+        boolean sinTelefono = chkSinTelefono != null && chkSinTelefono.isSelected();
 
         if (!diario && (dpFechaInicio.getValue() == null || cbArea.getValue() == null)) {
             mostrarAlerta("Error", "Debe completar todos los campos");
@@ -173,7 +199,11 @@ public class RegistroClienteController {
             } else {
                 stmtCliente.setString(1, validarCampo(txtNombres.getText(), "Nombres"));
                 stmtCliente.setString(2, validarCampo(txtApellidos.getText(), "Apellidos"));
-                stmtCliente.setString(3, validarCampo(txtTelefono.getText(), "Teléfono"));
+                if (sinTelefono) {
+                    stmtCliente.setString(3, generarTelefonoTemporal());
+                } else {
+                    stmtCliente.setString(3, validarCampo(txtTelefono.getText(), "Teléfono"));
+                }
             }
 
             stmtCliente.setString(4, cbMembresia.getValue());
@@ -238,7 +268,7 @@ public class RegistroClienteController {
             mostrarAlertaExito();
 
             // ✅ Enviar alerta de registro
-            if (!diario) {
+            if (!diario && !sinTelefono) {
                 Cliente nuevoCliente = new Cliente(
                         txtNombres.getText().trim(),
                         txtApellidos.getText().trim(),
@@ -282,6 +312,25 @@ public class RegistroClienteController {
         } catch (SQLException e) {
             e.printStackTrace();
         }
+    }
+
+    private void actualizarEstadoTelefono(boolean sinTelefono) {
+        if (txtTelefono != null) {
+            txtTelefono.setDisable(sinTelefono);
+            if (sinTelefono) {
+                txtTelefono.clear();
+                txtTelefono.setPromptText("Sin teléfono");
+            } else {
+                txtTelefono.setPromptText(null);
+            }
+        }
+        if (chkSinTelefono != null && chkSinTelefono.isDisabled() && chkSinTelefono.isSelected()) {
+            chkSinTelefono.setSelected(false);
+        }
+    }
+
+    private String generarTelefonoTemporal() {
+        return "SIN_TEL_" + System.currentTimeMillis();
     }
 
     private void programarRetornoAlDashboard() {

--- a/src/main/resources/fxml/registro_cliente.fxml
+++ b/src/main/resources/fxml/registro_cliente.fxml
@@ -37,9 +37,13 @@
                                       -fx-border-radius: 8; -fx-background-radius: 8; -fx-padding: 10;"/>
                     <Label text="Teléfono:" GridPane.rowIndex="2" GridPane.columnIndex="0"
                            style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
-                    <TextField fx:id="txtTelefono" GridPane.rowIndex="2" GridPane.columnIndex="1"
-                               style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da;
-                                      -fx-border-radius: 8; -fx-background-radius: 8; -fx-padding: 10;"/>
+                    <HBox spacing="10" alignment="CENTER_LEFT" GridPane.rowIndex="2" GridPane.columnIndex="1">
+                        <TextField fx:id="txtTelefono" HBox.hgrow="ALWAYS"
+                                   style="-fx-background-color: rgba(255,255,255,0.9); -fx-border-color: #ced4da;
+                                          -fx-border-radius: 8; -fx-background-radius: 8; -fx-padding: 10;"/>
+                        <CheckBox fx:id="chkSinTelefono" text="Sin teléfono"
+                                  style="-fx-text-fill: white; -fx-font-size: 12px; -fx-font-weight: bold;"/>
+                    </HBox>
                     <Label text="Fecha de Inicio:" GridPane.rowIndex="3" GridPane.columnIndex="0"
                            style="-fx-text-fill: white; -fx-font-size: 14px; -fx-font-weight: bold;"/>
                     <DatePicker fx:id="dpFechaInicio" GridPane.rowIndex="3" GridPane.columnIndex="1"
@@ -90,7 +94,7 @@
                                    -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.3), 8, 0, 0, 2);"/>
                 </HBox>
             </VBox>
-            <Label text="Todos los campos son obligatorios"
+            <Label text="Todos los campos son obligatorios. Puede marcar \"Sin teléfono\" si el cliente no tiene uno."
                    style="-fx-text-fill: #bdc3c7; -fx-font-size: 14px; -fx-font-style: italic;"/>
         </VBox>
     </center>


### PR DESCRIPTION
## Summary
- prevent clientes con membresía diaria from appearing in the próximos a vencer table of the dashboard
- add a "Sin teléfono" checkbox to the registro de clientes form so receptionists can record members without a phone number
- adjust the registration flow to handle the new checkbox, generating placeholder identifiers and skipping WhatsApp alerts when a phone number is omitted

## Testing
- mvn -q -DskipTests compile *(fails: Maven Central returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d99e1bf794832f99a18e7b00175fe3