### PR TITLE
Exclude daily passes from active client metrics

### DIFF
--- a/src/main/java/controllers/ListaClientesController.java
+++ b/src/main/java/controllers/ListaClientesController.java
@@ -759,7 +759,8 @@ public class ListaClientesController implements Initializable {
 
     private void cargarClientes() {
         String sql = "SELECT nombres, apellidos, telefono, telefono_visible, tipoMembresia, fecha_vencimiento " +
-                "FROM clientes WHERE activo = 1";
+                "FROM clientes WHERE activo = 1 " +
+                "AND (tipoMembresia IS NULL OR LOWER(tipoMembresia) <> 'diario')";
 
         try (Connection conn = DatabaseUtil.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql);

--- a/src/main/java/controllers/RecepcionistaDashboardController.java
+++ b/src/main/java/controllers/RecepcionistaDashboardController.java
@@ -572,7 +572,8 @@ public class RecepcionistaDashboardController implements Initializable {
 
     private void cargarDatosTarjetas() {
         try (Connection conn = DatabaseUtil.getConnection()) {
-            String sqlClientes = "SELECT COUNT(*) AS total FROM clientes WHERE activo = 1";
+            String sqlClientes = "SELECT COUNT(*) AS total FROM clientes WHERE activo = 1 " +
+                    "AND (tipoMembresia IS NULL OR LOWER(tipoMembresia) <> 'diario')";
             try (PreparedStatement ps = conn.prepareStatement(sqlClientes);
                  ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {

--- a/src/main/java/controllers/RenovacionController.java
+++ b/src/main/java/controllers/RenovacionController.java
@@ -173,7 +173,8 @@ public class RenovacionController {
 
     private void cargarTodosClientesActivos() {
         String sql = "SELECT nombres, apellidos, telefono, telefono_visible, tipoMembresia, fecha_vencimiento " +
-                "FROM clientes WHERE activo = 1";
+                "FROM clientes WHERE activo = 1 " +
+                "AND (tipoMembresia IS NULL OR LOWER(tipoMembresia) <> 'diario')";
 
         cargarClientesDesdeSQL(sql, todosClientes);
     }

--- a/src/main/java/util/DatabaseUtil.java
+++ b/src/main/java/util/DatabaseUtil.java
@@ -748,8 +748,8 @@ public class DatabaseUtil {
     public static Map<String, Integer> getEstadisticas() throws SQLException {
         Map<String, Integer> stats = new HashMap<>();
         String sql = """
-        SELECT 
-            (SELECT COUNT(*) FROM clientes WHERE activo = 1) AS clientes_activos,
+        SELECT
+            (SELECT COUNT(*) FROM clientes WHERE activo = 1 AND (tipoMembresia IS NULL OR LOWER(tipoMembresia) <> 'diario')) AS clientes_activos,
             (SELECT COUNT(*) FROM pagos WHERE date(fecha_pago) = CURRENT_DATE AND estado = 'ACTIVO') AS pagos_hoy,
             (SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento BETWEEN CURRENT_DATE AND date('now', '+7 days') AND LOWER(tipoMembresia) <> 'diario') AS por_vencer
         """;
@@ -771,13 +771,13 @@ public class DatabaseUtil {
         Map<String, Integer> stats = new HashMap<>();
         String sql = """
         SELECT
-            (SELECT COUNT(*) FROM clientes WHERE activo = 1) AS clientes_activos,
+            (SELECT COUNT(*) FROM clientes WHERE activo = 1 AND (tipoMembresia IS NULL OR LOWER(tipoMembresia) <> 'diario')) AS clientes_activos,
             (SELECT COUNT(*) FROM clientes WHERE activo = 0) AS clientes_inactivos,
             (SELECT COUNT(*) FROM pagos WHERE strftime('%Y-%m', fecha_pago) = strftime('%Y-%m','now') AND estado = 'ACTIVO') AS membresias_mes,
             (SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento BETWEEN date('now') AND date('now', '+7 day') AND LOWER(tipoMembresia) <> 'diario') AS por_vencer,
-            (SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento < date('now') AND activo = 1) AS clientes_morosos,
+            (SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento < date('now') AND activo = 1 AND (tipoMembresia IS NULL OR LOWER(tipoMembresia) <> 'diario')) AS clientes_morosos,
             (SELECT COALESCE(MAX(cantidad),0) FROM (SELECT COUNT(*) AS cantidad FROM clientes WHERE coach_id IS NOT NULL GROUP BY coach_id)) AS coaches_top,
-            (SELECT COUNT(*) FROM clientes WHERE activo = 1 AND date(fecha_inicio) <= date('now') AND date(fecha_vencimiento) >= date('now')) AS activos_hoy
+            (SELECT COUNT(*) FROM clientes WHERE activo = 1 AND (tipoMembresia IS NULL OR LOWER(tipoMembresia) <> 'diario') AND date(fecha_inicio) <= date('now') AND date(fecha_vencimiento) >= date('now')) AS activos_hoy
         """;
 
         try (Connection conn = getConnection();
@@ -2238,7 +2238,8 @@ public class DatabaseUtil {
     }
 
     public static int contarClientesMorosos() throws SQLException {
-        String sql = "SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento < date('now') AND activo = 1";
+        String sql = "SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento < date('now') AND activo = 1 " +
+                "AND (tipoMembresia IS NULL OR LOWER(tipoMembresia) <> 'diario')";
         try (Connection conn = getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql);
              ResultSet rs = stmt.executeQuery()) {
@@ -2247,7 +2248,8 @@ public class DatabaseUtil {
     }
 
     public static int contarClientesActivos() throws SQLException {
-        String sql = "SELECT COUNT(*) FROM clientes WHERE activo = 1";
+        String sql = "SELECT COUNT(*) FROM clientes WHERE activo = 1 " +
+                "AND (tipoMembresia IS NULL OR LOWER(tipoMembresia) <> 'diario')";
         try (Connection conn = getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql);
              ResultSet rs = stmt.executeQuery()) {


### PR DESCRIPTION
## Summary
- omit daily pass entries from the active clients table so they no longer appear as registered members
- update dashboard and reporting queries to exclude daily memberships from active client counts and overdue totals

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download maven-resources-plugin due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a5094c44832fb89ac3be0bf6ca83