### PR TITLE
Excluir clientes diarios de los conteos activos

### DIFF
--- a/src/main/java/controllers/ListaClientesController.java
+++ b/src/main/java/controllers/ListaClientesController.java
@@ -759,7 +759,8 @@ public class ListaClientesController implements Initializable {
 
     private void cargarClientes() {
         String sql = "SELECT nombres, apellidos, telefono, telefono_visible, tipoMembresia, fecha_vencimiento " +
-                "FROM clientes WHERE activo = 1";
+                "FROM clientes WHERE activo = 1 " +
+                "AND COALESCE(LOWER(tipoMembresia), '') <> 'diario'";
 
         try (Connection conn = DatabaseUtil.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql);

--- a/src/main/java/controllers/RecepcionistaDashboardController.java
+++ b/src/main/java/controllers/RecepcionistaDashboardController.java
@@ -572,7 +572,8 @@ public class RecepcionistaDashboardController implements Initializable {
 
     private void cargarDatosTarjetas() {
         try (Connection conn = DatabaseUtil.getConnection()) {
-            String sqlClientes = "SELECT COUNT(*) AS total FROM clientes WHERE activo = 1";
+            String sqlClientes = "SELECT COUNT(*) AS total FROM clientes WHERE activo = 1 " +
+                    "AND COALESCE(LOWER(tipoMembresia), '') <> 'diario'";
             try (PreparedStatement ps = conn.prepareStatement(sqlClientes);
                  ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {

--- a/src/main/java/controllers/RenovacionController.java
+++ b/src/main/java/controllers/RenovacionController.java
@@ -173,7 +173,8 @@ public class RenovacionController {
 
     private void cargarTodosClientesActivos() {
         String sql = "SELECT nombres, apellidos, telefono, telefono_visible, tipoMembresia, fecha_vencimiento " +
-                "FROM clientes WHERE activo = 1";
+                "FROM clientes WHERE activo = 1 " +
+                "AND COALESCE(LOWER(tipoMembresia), '') <> 'diario'";
 
         cargarClientesDesdeSQL(sql, todosClientes);
     }

--- a/src/main/java/util/DatabaseUtil.java
+++ b/src/main/java/util/DatabaseUtil.java
@@ -748,8 +748,8 @@ public class DatabaseUtil {
     public static Map<String, Integer> getEstadisticas() throws SQLException {
         Map<String, Integer> stats = new HashMap<>();
         String sql = """
-        SELECT 
-            (SELECT COUNT(*) FROM clientes WHERE activo = 1) AS clientes_activos,
+        SELECT
+            (SELECT COUNT(*) FROM clientes WHERE activo = 1 AND COALESCE(LOWER(tipoMembresia), '') <> 'diario') AS clientes_activos,
             (SELECT COUNT(*) FROM pagos WHERE date(fecha_pago) = CURRENT_DATE AND estado = 'ACTIVO') AS pagos_hoy,
             (SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento BETWEEN CURRENT_DATE AND date('now', '+7 days') AND LOWER(tipoMembresia) <> 'diario') AS por_vencer
         """;
@@ -771,13 +771,13 @@ public class DatabaseUtil {
         Map<String, Integer> stats = new HashMap<>();
         String sql = """
         SELECT
-            (SELECT COUNT(*) FROM clientes WHERE activo = 1) AS clientes_activos,
+            (SELECT COUNT(*) FROM clientes WHERE activo = 1 AND COALESCE(LOWER(tipoMembresia), '') <> 'diario') AS clientes_activos,
             (SELECT COUNT(*) FROM clientes WHERE activo = 0) AS clientes_inactivos,
             (SELECT COUNT(*) FROM pagos WHERE strftime('%Y-%m', fecha_pago) = strftime('%Y-%m','now') AND estado = 'ACTIVO') AS membresias_mes,
             (SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento BETWEEN date('now') AND date('now', '+7 day') AND LOWER(tipoMembresia) <> 'diario') AS por_vencer,
             (SELECT COUNT(*) FROM clientes WHERE fecha_vencimiento < date('now') AND activo = 1) AS clientes_morosos,
             (SELECT COALESCE(MAX(cantidad),0) FROM (SELECT COUNT(*) AS cantidad FROM clientes WHERE coach_id IS NOT NULL GROUP BY coach_id)) AS coaches_top,
-            (SELECT COUNT(*) FROM clientes WHERE activo = 1 AND date(fecha_inicio) <= date('now') AND date(fecha_vencimiento) >= date('now')) AS activos_hoy
+            (SELECT COUNT(*) FROM clientes WHERE activo = 1 AND COALESCE(LOWER(tipoMembresia), '') <> 'diario' AND date(fecha_inicio) <= date('now') AND date(fecha_vencimiento) >= date('now')) AS activos_hoy
         """;
 
         try (Connection conn = getConnection();
@@ -2247,7 +2247,7 @@ public class DatabaseUtil {
     }
 
     public static int contarClientesActivos() throws SQLException {
-        String sql = "SELECT COUNT(*) FROM clientes WHERE activo = 1";
+        String sql = "SELECT COUNT(*) FROM clientes WHERE activo = 1 AND COALESCE(LOWER(tipoMembresia), '') <> 'diario'";
         try (Connection conn = getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql);
              ResultSet rs = stmt.executeQuery()) {


### PR DESCRIPTION
## Summary
- excluir a los clientes con membresía diaria de la consulta de clientes activos en la lista y las pantallas de renovación
- ajustar las tarjetas del panel de recepción y los servicios de métricas para omitir a los clientes diarios en los conteos activos

## Testing
- mvn -q -DskipTests package *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e6386a80832fb33699b701be1a80