### PR TITLE
Forzar mayúsculas en usuario de admin y recepcionista

### DIFF
--- a/src/main/java/controllers/CrearAdminController.java
+++ b/src/main/java/controllers/CrearAdminController.java
@@ -8,6 +8,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.Label;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
 import javafx.stage.Stage;
 import models.Role;
 import models.User;
@@ -15,6 +16,7 @@ import util.UserService;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.function.UnaryOperator;
 
 public class CrearAdminController {
     @FXML private TextField txtUsuario;
@@ -23,6 +25,11 @@ public class CrearAdminController {
     @FXML private Label lblMensaje;
 
     private Stage stage;
+
+    @FXML
+    private void initialize() {
+        configurarTextFieldMayusculas(txtUsuario);
+    }
 
     public void setStage(Stage stage) {
         this.stage = stage;
@@ -78,6 +85,21 @@ public class CrearAdminController {
     private void mostrarMensaje(String mensaje, boolean error) {
         lblMensaje.setText(mensaje);
         lblMensaje.setStyle(error ? "-fx-text-fill: #ff6b6b;" : "-fx-text-fill: #2ecc71;");
+    }
+
+    private void configurarTextFieldMayusculas(TextField textField) {
+        if (textField == null) {
+            return;
+        }
+        UnaryOperator<TextFormatter.Change> filter = change -> {
+            String nuevoTexto = change.getText();
+            if (nuevoTexto != null) {
+                change.setText(nuevoTexto.toUpperCase());
+            }
+            return change;
+        };
+        TextFormatter<String> textFormatter = new TextFormatter<>(filter);
+        textField.setTextFormatter(textFormatter);
     }
 
     private void mostrarAlerta(String mensaje) {

--- a/src/main/java/controllers/RegistroRecepcionistaController.java
+++ b/src/main/java/controllers/RegistroRecepcionistaController.java
@@ -5,12 +5,14 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.Label;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
 import javafx.stage.Stage;
 import models.Role;
 import models.User;
 import util.UserService;
 
 import java.sql.SQLException;
+import java.util.function.UnaryOperator;
 
 public class RegistroRecepcionistaController {
     @FXML private TextField txtUsuario;
@@ -22,6 +24,11 @@ public class RegistroRecepcionistaController {
     private Stage stage;
     private User usuarioEditando;
     private Runnable onSave;
+
+    @FXML
+    private void initialize() {
+        configurarTextFieldMayusculas(txtUsuario);
+    }
 
     public void setStage(Stage stage) {
         this.stage = stage;
@@ -39,7 +46,7 @@ public class RegistroRecepcionistaController {
         if (lblTitulo != null) {
             lblTitulo.setText("Editar recepcionista");
         }
-        txtUsuario.setText(user.getUsername());
+        txtUsuario.setText(user.getUsername() != null ? user.getUsername().toUpperCase() : "");
         if (lblMensaje != null) {
             lblMensaje.setText("");
         }
@@ -110,5 +117,20 @@ public class RegistroRecepcionistaController {
             alert.setContentText(mensaje);
             alert.showAndWait();
         }
+    }
+
+    private void configurarTextFieldMayusculas(TextField textField) {
+        if (textField == null) {
+            return;
+        }
+        UnaryOperator<TextFormatter.Change> filter = change -> {
+            String nuevoTexto = change.getText();
+            if (nuevoTexto != null) {
+                change.setText(nuevoTexto.toUpperCase());
+            }
+            return change;
+        };
+        TextFormatter<String> textFormatter = new TextFormatter<>(filter);
+        textField.setTextFormatter(textFormatter);
     }
 }


### PR DESCRIPTION
## Summary
- aplicar un formateador que convierte a mayúsculas el texto introducido en el campo de usuario al crear administradores
- reutilizar la misma lógica en el registro y edición de recepcionistas y normalizar los valores cargados existentes

## Testing
- no se ejecutaron pruebas (no aplicable)


------
https://chatgpt.com/codex/tasks/task_e_68da207488c4832fa902bbb02f2909bb