### PR TITLE
Mejorar estilos del selector de perfiles

### DIFF
--- a/src/main/java/controllers/SelectorPerfilesController.java
+++ b/src/main/java/controllers/SelectorPerfilesController.java
@@ -214,34 +214,29 @@ public class SelectorPerfilesController {
         imageView.setPreserveRatio(true);
 
         Label nombre = new Label(user.getUsername());
-        nombre.setStyle("-fx-text-fill: white; -fx-font-size: 16px; -fx-font-weight: bold;");
+        nombre.getStyleClass().add("nombre-usuario");
 
         VBox tarjeta = new VBox(10, imageView, nombre);
+        tarjeta.setAlignment(Pos.CENTER);
         tarjeta.setMinSize(140, 160);
         tarjeta.setPrefSize(140, 160);
         tarjeta.setMaxSize(140, 160);
-        tarjeta.setStyle("-fx-alignment: center; -fx-padding: 15; -fx-background-color: rgba(0,0,0,0.45);"
-                + " -fx-background-radius: 15; -fx-cursor: hand;");
+        tarjeta.setFocusTraversable(true);
+        tarjeta.getStyleClass().add("tarjeta-usuario");
         tarjeta.setOnMouseClicked(e -> abrirLogin(user));
-        tarjeta.setOnMouseEntered(e -> tarjeta.setStyle("-fx-alignment: center; -fx-padding: 15;"
-                + " -fx-background-color: rgba(255,255,255,0.2); -fx-background-radius: 15; -fx-cursor: hand;"));
-        tarjeta.setOnMouseExited(e -> tarjeta.setStyle("-fx-alignment: center; -fx-padding: 15;"
-                + " -fx-background-color: rgba(0,0,0,0.45); -fx-background-radius: 15; -fx-cursor: hand;"));
         return tarjeta;
     }
 
     private StackPane crearTarjetaAgregar() {
         Button boton = new Button("Añadir perfil");
-        boton.setStyle("-fx-background-color: #ffb703; -fx-text-fill: #1f1f1f; -fx-font-weight: bold;"
-                + " -fx-background-radius: 25; -fx-padding: 12 20; -fx-cursor: hand;");
+        boton.getStyleClass().add("boton-agregar");
         boton.setOnAction(e -> abrirRegistroRecepcionista());
 
         StackPane tarjeta = new StackPane(boton);
         tarjeta.setMinSize(140, 160);
         tarjeta.setPrefSize(140, 160);
         tarjeta.setMaxSize(140, 160);
-        tarjeta.setStyle("-fx-background-color: rgba(255,255,255,0.15); -fx-background-radius: 15;"
-                + " -fx-padding: 15; -fx-cursor: hand;");
+        tarjeta.getStyleClass().add("tarjeta-agregar");
         return tarjeta;
     }
 

--- a/src/main/resources/css/selector_perfiles.css
+++ b/src/main/resources/css/selector_perfiles.css
@@ -1,0 +1,74 @@
+.selector-scroll {
+    -fx-background-color: transparent;
+    -fx-background: transparent;
+    -fx-border-color: transparent;
+}
+
+.selector-scroll .viewport {
+    -fx-background-color: transparent;
+}
+
+.selector-scroll .corner {
+    -fx-background-color: transparent;
+}
+
+.contenedor-perfiles {
+    -fx-padding: 20 10 40 10;
+}
+
+.tarjeta-usuario {
+    -fx-alignment: center;
+    -fx-padding: 15;
+    -fx-background-color: rgba(0, 0, 0, 0.45);
+    -fx-background-radius: 18;
+    -fx-border-radius: 18;
+    -fx-border-color: rgba(255, 255, 255, 0.25);
+    -fx-border-width: 1.2;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.35), 12, 0.25, 0, 6);
+    -fx-cursor: hand;
+    -fx-spacing: 10;
+}
+
+.tarjeta-usuario:hover,
+.tarjeta-usuario:focused {
+    -fx-background-color: rgba(255, 255, 255, 0.18);
+    -fx-border-color: #ffb703;
+    -fx-effect: dropshadow(gaussian, rgba(255, 183, 3, 0.45), 16, 0.35, 0, 6);
+}
+
+.nombre-usuario {
+    -fx-text-fill: white;
+    -fx-font-size: 16px;
+    -fx-font-weight: bold;
+}
+
+.tarjeta-agregar {
+    -fx-background-color: rgba(255, 255, 255, 0.08);
+    -fx-background-radius: 18;
+    -fx-border-radius: 18;
+    -fx-border-color: rgba(255, 255, 255, 0.25);
+    -fx-border-width: 1.2;
+    -fx-padding: 15;
+    -fx-cursor: hand;
+    -fx-alignment: center;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.25), 12, 0.25, 0, 6);
+}
+
+.tarjeta-agregar:hover {
+    -fx-border-color: #ffb703;
+    -fx-effect: dropshadow(gaussian, rgba(255, 183, 3, 0.45), 16, 0.35, 0, 6);
+}
+
+.boton-agregar {
+    -fx-background-color: #ffb703;
+    -fx-text-fill: #1f1f1f;
+    -fx-font-weight: bold;
+    -fx-background-radius: 25;
+    -fx-padding: 12 20;
+    -fx-cursor: hand;
+    -fx-font-size: 14px;
+}
+
+.boton-agregar:hover {
+    -fx-background-color: #ffd166;
+}

--- a/src/main/resources/fxml/selector_perfiles.fxml
+++ b/src/main/resources/fxml/selector_perfiles.fxml
@@ -5,7 +5,8 @@
 <BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="controllers.SelectorPerfilesController"
             prefWidth="700" prefHeight="420"
-            style="-fx-background-color: linear-gradient(to bottom, #0f2027, #203a43, #2c5364); -fx-padding: 20;">
+            style="-fx-background-color: linear-gradient(to bottom, #0f2027, #203a43, #2c5364); -fx-padding: 20;"
+            stylesheets="@../css/selector_perfiles.css">
     <top>
         <VBox alignment="CENTER" spacing="8">
             <Label text="Selecciona un perfil"
@@ -15,11 +16,11 @@
     </top>
     <center>
         <ScrollPane fitToWidth="true" fitToHeight="true" hbarPolicy="NEVER" vbarPolicy="AS_NEEDED"
-                    style="-fx-background-color: transparent;">
+                    styleClass="selector-scroll">
             <content>
                 <FlowPane fx:id="contenedorPerfiles" prefWidth="600" prefHeight="300"
                           alignment="CENTER" hgap="20" vgap="20"
-                          style="-fx-padding: 20;"/>
+                          styleClass="contenedor-perfiles"/>
             </content>
         </ScrollPane>
     </center>


### PR DESCRIPTION
## Summary
- aplicar una hoja de estilos dedicada al selector de perfiles para mantener el fondo oscuro y resaltar el área de perfiles
- actualizar la construcción de tarjetas para usar clases CSS que realzan el perfil elegido y el botón de alta

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da242b2050832f8817954b8f0ee09e