### PR TITLE
Añade iconos diferenciados por rol en selector de perfiles

### DIFF
--- a/src/main/java/controllers/SelectorPerfilesController.java
+++ b/src/main/java/controllers/SelectorPerfilesController.java
@@ -10,8 +10,6 @@ import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.GridPane;
@@ -208,15 +206,11 @@ public class SelectorPerfilesController {
     }
 
     private VBox crearTarjetaUsuario(User user) {
-        ImageView imageView = new ImageView(new Image(getClass().getResourceAsStream("/images/gym.png")));
-        imageView.setFitWidth(100);
-        imageView.setFitHeight(100);
-        imageView.setPreserveRatio(true);
-
+        StackPane icono = crearIconoRol(user.getRole());
         Label nombre = new Label(user.getUsername());
         nombre.getStyleClass().add("nombre-usuario");
 
-        VBox tarjeta = new VBox(10, imageView, nombre);
+        VBox tarjeta = new VBox(12, icono, nombre);
         tarjeta.setAlignment(Pos.CENTER);
         tarjeta.setMinSize(140, 160);
         tarjeta.setPrefSize(140, 160);
@@ -225,6 +219,28 @@ public class SelectorPerfilesController {
         tarjeta.getStyleClass().add("tarjeta-usuario");
         tarjeta.setOnMouseClicked(e -> abrirLogin(user));
         return tarjeta;
+    }
+
+    private StackPane crearIconoRol(Role role) {
+        StackPane icono = new StackPane();
+        icono.getStyleClass().add("icono-usuario");
+
+        String estiloRol;
+        String simbolo;
+        if (role == Role.ADMIN) {
+            estiloRol = "icono-admin";
+            simbolo = "\uD83D\uDC51"; // 👑
+        } else {
+            estiloRol = "icono-recepcionista";
+            simbolo = "\uD83D\uDCBC"; // 💼
+        }
+        icono.getStyleClass().add(estiloRol);
+
+        Label etiqueta = new Label(simbolo);
+        etiqueta.getStyleClass().add("emoji-icono");
+        icono.getChildren().add(etiqueta);
+
+        return icono;
     }
 
     private StackPane crearTarjetaAgregar() {

--- a/src/main/resources/css/selector_perfiles.css
+++ b/src/main/resources/css/selector_perfiles.css
@@ -42,6 +42,37 @@
     -fx-font-weight: bold;
 }
 
+.icono-usuario {
+    -fx-min-width: 110px;
+    -fx-min-height: 110px;
+    -fx-pref-width: 110px;
+    -fx-pref-height: 110px;
+    -fx-max-width: 110px;
+    -fx-max-height: 110px;
+    -fx-background-radius: 55px;
+    -fx-alignment: center;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.35), 12, 0.25, 0, 6);
+}
+
+.icono-admin {
+    -fx-background-color: linear-gradient(to bottom, #f8b500, #f7a100, #f38b00);
+    -fx-border-color: rgba(255, 255, 255, 0.35);
+    -fx-border-width: 2px;
+    -fx-border-radius: 55px;
+}
+
+.icono-recepcionista {
+    -fx-background-color: linear-gradient(to bottom, #2d9cdb, #2571c0, #1b4f99);
+    -fx-border-color: rgba(255, 255, 255, 0.35);
+    -fx-border-width: 2px;
+    -fx-border-radius: 55px;
+}
+
+.emoji-icono {
+    -fx-font-size: 52px;
+    -fx-text-fill: white;
+}
+
 .tarjeta-agregar {
     -fx-background-color: rgba(255, 255, 255, 0.08);
     -fx-background-radius: 18;


### PR DESCRIPTION
## Summary
- reemplaza el icono genérico de cada tarjeta por un emblema asociado al rol del usuario
- incorpora estilos específicos para los iconos de administrador y recepcionista en la vista de selección de perfiles

## Testing
- mvn -q -DskipTests compile *(falla: repositorio Maven bloqueado - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68da2668a794832fa4593000acac2ae2