### PR TITLE
Evitar selección inicial de tarjeta en selector de perfiles

### DIFF
--- a/src/main/java/controllers/SelectorPerfilesController.java
+++ b/src/main/java/controllers/SelectorPerfilesController.java
@@ -76,9 +76,30 @@ public class SelectorPerfilesController {
 
             VBox disposicion = construirDisposicionPerfiles(administradorPrincipal, recepcionistas);
             contenedorPerfiles.getChildren().add(disposicion);
+            limpiarSeleccionInicial();
         } catch (SQLException e) {
             lblMensaje.setText("No se pudieron cargar los usuarios");
             lblMensaje.setStyle("-fx-text-fill: #ff6b6b;");
+        }
+    }
+
+    private void limpiarSeleccionInicial() {
+        if (contenedorPerfiles == null) {
+            return;
+        }
+
+        Scene escena = contenedorPerfiles.getScene();
+        if (escena == null) {
+            Platform.runLater(this::limpiarSeleccionInicial);
+            return;
+        }
+
+        Parent raiz = escena.getRoot();
+        if (raiz != null) {
+            if (!raiz.isFocusTraversable()) {
+                raiz.setFocusTraversable(true);
+            }
+            raiz.requestFocus();
         }
     }
 


### PR DESCRIPTION
## Summary
- evita que al cargar el selector de perfiles quede seleccionada la tarjeta del administrador
- solicita el foco en el contenedor raíz tras poblar los perfiles para limpiar cualquier foco previo

## Testing
- no se añadieron pruebas automatizadas

------
https://chatgpt.com/codex/tasks/task_e_68da28d98220832fab002652dff037f3