### PR TITLE
Ajusta respaldo diario para mantener un único archivo por día

### DIFF
--- a/src/main/java/util/BackupUtil.java
+++ b/src/main/java/util/BackupUtil.java
@@ -2,6 +2,7 @@ package util;
 
 import java.io.IOException;
 import java.nio.file.*;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -35,9 +36,17 @@ public class BackupUtil implements Runnable {
             if (!Files.exists(dir)) {
                 Files.createDirectories(dir);
             }
-            String timestamp = LocalDateTime.now()
-                    .format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
-            Path destino = dir.resolve("gimnasio_" + timestamp + ".db");
+            LocalDateTime ahora = LocalDateTime.now();
+            String nombreArchivo;
+            if ("diario".equalsIgnoreCase(tipo)) {
+                String fecha = LocalDate.now()
+                        .format(DateTimeFormatter.BASIC_ISO_DATE);
+                nombreArchivo = "gimnasio_" + fecha + ".db";
+            } else {
+                String timestamp = ahora.format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+                nombreArchivo = "gimnasio_" + timestamp + ".db";
+            }
+            Path destino = dir.resolve(nombreArchivo);
             Files.copy(DB_PATH, destino, StandardCopyOption.REPLACE_EXISTING);
             System.out.println("Backup " + tipo + " creado: " + destino);
         } catch (IOException e) {


### PR DESCRIPTION
## Summary
- actualiza la utilidad de respaldos para reutilizar el mismo archivo diario en lugar de crear múltiples copias con hora
- mantiene los respaldos de otros tipos con marca de tiempo para conservar el comportamiento existente

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da2a749a00832fb67ef8ef6d3543eb