### PR TITLE
Add equipment inventory history tracking and reporting

### DIFF
--- a/src/main/java/controllers/EquiposAdminController.java
+++ b/src/main/java/controllers/EquiposAdminController.java
@@ -32,6 +32,7 @@ import util.UserService;
 import java.net.URL;
 import java.sql.SQLException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.Locale;
@@ -354,7 +355,10 @@ public class EquiposAdminController implements Initializable {
         Optional<Equipo> resultado = dialogo.showAndWait();
         resultado.ifPresent(equipo -> {
             try {
-                DatabaseUtil.insertarEquipo(equipo);
+                int equipoId = DatabaseUtil.insertarEquipo(equipo);
+                equipo.setId(equipoId);
+                registrarMovimientoCantidad(equipoId, null, equipo.getCantidad(), "INICIAL",
+                        equipo.getFechaAdquisicionDate(), "Registro inicial");
                 registrarAuditoria("REGISTRO_EQUIPO", "Se registró el equipo " + equipo.getNombre());
                 cargarEquipos();
                 mostrarInformacion("Éxito", "Equipo registrado correctamente.");
@@ -375,7 +379,23 @@ public class EquiposAdminController implements Initializable {
         Optional<Equipo> resultado = dialogo.showAndWait();
         resultado.ifPresent(equipoActualizado -> {
             try {
+                int cantidadAnterior = seleccionado.getCantidad();
+                boolean cambioCantidad = cantidadAnterior != equipoActualizado.getCantidad();
+                MovimientoMetadata metadata = null;
+                if (cambioCantidad) {
+                    Optional<MovimientoMetadata> metadatos = solicitarDetallesMovimiento(cantidadAnterior, equipoActualizado.getCantidad());
+                    if (metadatos.isEmpty()) {
+                        return;
+                    }
+                    metadata = metadatos.get();
+                }
+
                 DatabaseUtil.actualizarEquipo(equipoActualizado);
+                if (cambioCantidad) {
+                    registrarMovimientoCantidad(equipoActualizado.getId(), cantidadAnterior,
+                            equipoActualizado.getCantidad(), "AJUSTE",
+                            metadata.fechaMovimiento(), metadata.nota());
+                }
                 registrarAuditoria("ACTUALIZACION_EQUIPO", "Se actualizó el equipo " + equipoActualizado.getNombre());
                 cargarEquipos();
                 mostrarInformacion("Éxito", "Equipo actualizado correctamente.");
@@ -417,6 +437,22 @@ public class EquiposAdminController implements Initializable {
         } catch (Exception ex) {
             mostrarError("Error", "No se pudo generar el reporte.");
         }
+    }
+
+    @FXML
+    private void handleGenerarInformeHistorico() {
+        Optional<PeriodoReporte> periodo = solicitarPeriodoReporte();
+        periodo.ifPresent(rango -> {
+            try {
+                ReporteUtil.generarInformeEquiposPeriodo(rango.inicio(), rango.fin(), true);
+                registrarAuditoria("INFORME_EQUIPOS", String.format(
+                        "Informe histórico de equipos (%s - %s)",
+                        rango.inicio() != null ? rango.inicio() : "--",
+                        rango.fin() != null ? rango.fin() : "--"));
+            } catch (RuntimeException ex) {
+                mostrarError("Error", "No se pudo generar el informe histórico.");
+            }
+        });
     }
 
     private Dialog<Equipo> crearDialogoEquipo(Equipo equipoExistente) {
@@ -863,4 +899,120 @@ public class EquiposAdminController implements Initializable {
         alert.setContentText(mensaje);
         alert.showAndWait();
     }
+
+    private void registrarMovimientoCantidad(int equipoId, Integer cantidadAnterior, int cantidadNueva,
+                                             String tipoMovimiento, LocalDate fechaMovimiento, String nota) {
+        User usuario = SessionManager.getCurrentUser();
+        Integer usuarioId = usuario != null ? usuario.getId() : null;
+        LocalDateTime fecha = fechaMovimiento != null ? fechaMovimiento.atStartOfDay() : LocalDateTime.now();
+        try {
+            DatabaseUtil.registrarMovimientoEquipo(equipoId, cantidadAnterior, cantidadNueva,
+                    tipoMovimiento, fecha, usuarioId, nota);
+        } catch (SQLException e) {
+            System.err.println("No se pudo registrar el historial del equipo: " + e.getMessage());
+        }
+    }
+
+    private Optional<MovimientoMetadata> solicitarDetallesMovimiento(int cantidadAnterior, int cantidadNueva) {
+        Dialog<MovimientoMetadata> dialogo = new Dialog<>();
+        dialogo.setTitle("Registrar cambio de cantidad");
+        dialogo.setHeaderText(null);
+
+        ButtonType btnGuardar = new ButtonType("Registrar", ButtonBar.ButtonData.OK_DONE);
+        dialogo.getDialogPane().getButtonTypes().addAll(btnGuardar, ButtonType.CANCEL);
+        dialogo.getDialogPane().getStylesheets().add(getClass().getResource("/css/dashboard.css").toExternalForm());
+        dialogo.getDialogPane().getStyleClass().add("dialog-dark-pane");
+
+        Label lblResumen = new Label(String.format("Cantidad anterior: %d | Nueva cantidad: %d | Variación: %+d",
+                cantidadAnterior, cantidadNueva, cantidadNueva - cantidadAnterior));
+        lblResumen.getStyleClass().add("dialog-label");
+
+        DatePicker dpFecha = estilizarCampo(new DatePicker(LocalDate.now()));
+        dpFecha.setPromptText("Fecha del movimiento");
+
+        TextArea txtNota = estilizarCampo(new TextArea());
+        txtNota.setPromptText("Descripción del cambio (opcional)");
+        txtNota.setPrefRowCount(3);
+        txtNota.setWrapText(true);
+
+        VBox contenedor = new VBox(12, lblResumen, dpFecha, txtNota);
+        contenedor.setFillWidth(true);
+
+        dialogo.getDialogPane().setContent(contenedor);
+
+        Node btnGuardarNode = dialogo.getDialogPane().lookupButton(btnGuardar);
+        if (btnGuardarNode != null) {
+            btnGuardarNode.addEventFilter(ActionEvent.ACTION, event -> {
+                if (dpFecha.getValue() == null) {
+                    mostrarAdvertencia("Validación", "Debe seleccionar la fecha del movimiento.");
+                    event.consume();
+                }
+            });
+        }
+
+        dialogo.setResultConverter(button -> {
+            if (button == btnGuardar) {
+                return new MovimientoMetadata(dpFecha.getValue(), txtNota.getText());
+            }
+            return null;
+        });
+
+        return dialogo.showAndWait();
+    }
+
+    private Optional<PeriodoReporte> solicitarPeriodoReporte() {
+        Dialog<PeriodoReporte> dialogo = new Dialog<>();
+        dialogo.setTitle("Informe histórico de equipos");
+        dialogo.setHeaderText("Seleccione el rango de fechas para el informe");
+
+        ButtonType btnGenerar = new ButtonType("Generar", ButtonBar.ButtonData.OK_DONE);
+        dialogo.getDialogPane().getButtonTypes().addAll(btnGenerar, ButtonType.CANCEL);
+        dialogo.getDialogPane().getStylesheets().add(getClass().getResource("/css/dashboard.css").toExternalForm());
+        dialogo.getDialogPane().getStyleClass().add("dialog-dark-pane");
+
+        LocalDate hoy = LocalDate.now();
+        DatePicker dpInicio = estilizarCampo(new DatePicker(hoy.withDayOfYear(1)));
+        dpInicio.setPromptText("Fecha de inicio");
+
+        DatePicker dpFin = estilizarCampo(new DatePicker(hoy));
+        dpFin.setPromptText("Fecha de fin");
+
+        GridPane grid = new GridPane();
+        grid.setHgap(10);
+        grid.setVgap(10);
+        grid.add(crearEtiquetaCampo("Desde:"), 0, 0);
+        grid.add(dpInicio, 1, 0);
+        grid.add(crearEtiquetaCampo("Hasta:"), 0, 1);
+        grid.add(dpFin, 1, 1);
+
+        dialogo.getDialogPane().setContent(grid);
+
+        Node btnGenerarNode = dialogo.getDialogPane().lookupButton(btnGenerar);
+        if (btnGenerarNode != null) {
+            btnGenerarNode.addEventFilter(ActionEvent.ACTION, event -> {
+                LocalDate inicio = dpInicio.getValue();
+                LocalDate fin = dpFin.getValue();
+                if (inicio == null || fin == null) {
+                    mostrarAdvertencia("Validación", "Debe seleccionar ambas fechas para generar el informe.");
+                    event.consume();
+                } else if (fin.isBefore(inicio)) {
+                    mostrarAdvertencia("Validación", "La fecha de fin debe ser posterior a la fecha de inicio.");
+                    event.consume();
+                }
+            });
+        }
+
+        dialogo.setResultConverter(button -> {
+            if (button == btnGenerar) {
+                return new PeriodoReporte(dpInicio.getValue(), dpFin.getValue());
+            }
+            return null;
+        });
+
+        return dialogo.showAndWait();
+    }
+
+    private record MovimientoMetadata(LocalDate fechaMovimiento, String nota) {}
+
+    private record PeriodoReporte(LocalDate inicio, LocalDate fin) {}
 }

--- a/src/main/java/models/EquipoResumen.java
+++ b/src/main/java/models/EquipoResumen.java
@@ -1,0 +1,80 @@
+package models;
+
+public class EquipoResumen {
+    private int equipoId;
+    private String nombre;
+    private String tipo;
+    private int cantidadInicial;
+    private int altas;
+    private int bajas;
+    private int cantidadFinal;
+
+    public EquipoResumen() {
+    }
+
+    public EquipoResumen(int equipoId, String nombre, String tipo, int cantidadInicial, int altas, int bajas, int cantidadFinal) {
+        this.equipoId = equipoId;
+        this.nombre = nombre;
+        this.tipo = tipo;
+        this.cantidadInicial = cantidadInicial;
+        this.altas = altas;
+        this.bajas = bajas;
+        this.cantidadFinal = cantidadFinal;
+    }
+
+    public int getEquipoId() {
+        return equipoId;
+    }
+
+    public void setEquipoId(int equipoId) {
+        this.equipoId = equipoId;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(String tipo) {
+        this.tipo = tipo;
+    }
+
+    public int getCantidadInicial() {
+        return cantidadInicial;
+    }
+
+    public void setCantidadInicial(int cantidadInicial) {
+        this.cantidadInicial = cantidadInicial;
+    }
+
+    public int getAltas() {
+        return altas;
+    }
+
+    public void setAltas(int altas) {
+        this.altas = altas;
+    }
+
+    public int getBajas() {
+        return bajas;
+    }
+
+    public void setBajas(int bajas) {
+        this.bajas = bajas;
+    }
+
+    public int getCantidadFinal() {
+        return cantidadFinal;
+    }
+
+    public void setCantidadFinal(int cantidadFinal) {
+        this.cantidadFinal = cantidadFinal;
+    }
+}

--- a/src/main/java/util/DatabaseUtil.java
+++ b/src/main/java/util/DatabaseUtil.java
@@ -29,6 +29,7 @@ import models.ProveedorProducto;
 import models.CoachClientes;
 import models.Equipo;
 import models.IngresoData;
+import models.EquipoResumen;
 
 public class DatabaseUtil {
     private static final String URL = "jdbc:sqlite:database/gimnasio.db";
@@ -136,6 +137,19 @@ public class DatabaseUtil {
                 "fecha TEXT NOT NULL DEFAULT (datetime('now'))," +
                 "FOREIGN KEY (producto_id) REFERENCES productos(id))";
 
+        String sqlEquiposHistorial = "CREATE TABLE IF NOT EXISTS equipos_historial (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                "equipo_id INTEGER NOT NULL," +
+                "usuario_id INTEGER," +
+                "fecha TEXT NOT NULL DEFAULT (datetime('now'))," +
+                "tipo TEXT NOT NULL," +
+                "cantidad_anterior INTEGER," +
+                "cantidad_nueva INTEGER NOT NULL," +
+                "diferencia INTEGER NOT NULL," +
+                "nota TEXT," +
+                "FOREIGN KEY (equipo_id) REFERENCES equipos(id) ON DELETE CASCADE," +
+                "FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE SET NULL)";
+
         String sqlVentas = "CREATE TABLE IF NOT EXISTS ventas (" +
                 "id INTEGER PRIMARY KEY AUTOINCREMENT," +
                 "fecha TEXT NOT NULL DEFAULT (datetime('now','localtime'))," +
@@ -206,6 +220,7 @@ public class DatabaseUtil {
             try { stmt.execute("UPDATE pagos SET estado = 'ACTIVO' WHERE estado IS NULL"); } catch (SQLException ignored) {}
             stmt.execute(sqlProductos);
             stmt.execute(sqlInventarioHistorial);
+            stmt.execute(sqlEquiposHistorial);
             stmt.execute(sqlVentas);
             stmt.execute(sqlEgresos);
             stmt.execute(sqlCoaches);
@@ -1099,21 +1114,41 @@ public class DatabaseUtil {
         }
     }
 
-    public static void insertarEquipo(Equipo equipo) throws SQLException {
+    public static int insertarEquipo(Equipo equipo) throws SQLException {
         String sql = "INSERT INTO equipos (nombre, tipo, estado, cantidad, marca, modelo, peso, fecha_adquisicion, frecuencia_mantenimiento, fecha_ultimo_mantenimiento, ubicacion, descripcion) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
-        executeUpdate(sql,
-                equipo.getNombre(),
-                equipo.getTipo(),
-                equipo.getEstado(),
-                equipo.getCantidad(),
-                nullIfBlank(equipo.getMarca()),
-                nullIfBlank(equipo.getModelo()),
-                equipo.getPesoAsInteger(),
-                nullIfBlank(equipo.getFechaAdquisicion()),
-                nullIfBlank(equipo.getFrecuenciaMantenimiento()),
-                equipo.getFechaUltimoMantenimiento(),
-                equipo.getUbicacion(),
-                equipo.getDescripcion());
+
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            stmt.setString(1, equipo.getNombre());
+            stmt.setString(2, equipo.getTipo());
+            stmt.setString(3, equipo.getEstado());
+            stmt.setInt(4, equipo.getCantidad());
+            stmt.setString(5, nullIfBlank(equipo.getMarca()));
+            stmt.setString(6, nullIfBlank(equipo.getModelo()));
+            Integer peso = equipo.getPesoAsInteger();
+            if (peso != null) {
+                stmt.setInt(7, peso);
+            } else {
+                stmt.setNull(7, Types.INTEGER);
+            }
+            stmt.setString(8, nullIfBlank(equipo.getFechaAdquisicion()));
+            stmt.setString(9, nullIfBlank(equipo.getFrecuenciaMantenimiento()));
+            if (equipo.getFechaUltimoMantenimiento() != null) {
+                stmt.setString(10, equipo.getFechaUltimoMantenimiento().toString());
+            } else {
+                stmt.setNull(10, Types.VARCHAR);
+            }
+            stmt.setString(11, equipo.getUbicacion());
+            stmt.setString(12, equipo.getDescripcion());
+            stmt.executeUpdate();
+
+            try (ResultSet rs = stmt.getGeneratedKeys()) {
+                if (rs.next()) {
+                    return rs.getInt(1);
+                }
+            }
+        }
+        throw new SQLException("No se pudo obtener el identificador del equipo registrado");
     }
 
     public static void actualizarEquipo(Equipo equipo) throws SQLException {
@@ -1132,6 +1167,83 @@ public class DatabaseUtil {
                 equipo.getUbicacion(),
                 equipo.getDescripcion(),
                 equipo.getId());
+    }
+
+    public static void registrarMovimientoEquipo(int equipoId, Integer cantidadAnterior, int cantidadNueva,
+                                                 String tipoMovimiento, LocalDateTime fechaMovimiento,
+                                                 Integer usuarioId, String nota) throws SQLException {
+        String sql = "INSERT INTO equipos_historial (equipo_id, usuario_id, fecha, tipo, cantidad_anterior, cantidad_nueva, diferencia, nota) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        int anterior = cantidadAnterior != null ? cantidadAnterior : 0;
+        int diferencia = cantidadNueva - anterior;
+
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, equipoId);
+            if (usuarioId != null) {
+                stmt.setInt(2, usuarioId);
+            } else {
+                stmt.setNull(2, Types.INTEGER);
+            }
+            LocalDateTime fecha = fechaMovimiento != null ? fechaMovimiento : LocalDateTime.now();
+            stmt.setString(3, formatDateTime(fecha));
+            stmt.setString(4, tipoMovimiento != null && !tipoMovimiento.isBlank() ? tipoMovimiento.trim().toUpperCase(Locale.ROOT) : "AJUSTE");
+            if (cantidadAnterior != null) {
+                stmt.setInt(5, cantidadAnterior);
+            } else {
+                stmt.setNull(5, Types.INTEGER);
+            }
+            stmt.setInt(6, cantidadNueva);
+            stmt.setInt(7, diferencia);
+            if (nota != null && !nota.isBlank()) {
+                stmt.setString(8, nota.trim());
+            } else {
+                stmt.setNull(8, Types.VARCHAR);
+            }
+            stmt.executeUpdate();
+        }
+    }
+
+    public static List<EquipoResumen> obtenerResumenEquipos(LocalDate fechaInicio, LocalDate fechaFin) throws SQLException {
+        List<EquipoResumen> resumen = new ArrayList<>();
+        LocalDateTime inicio = fechaInicio != null ? fechaInicio.atStartOfDay() : LocalDate.of(1970, 1, 1).atStartOfDay();
+        LocalDateTime fin = fechaFin != null ? fechaFin.atTime(23, 59, 59) : LocalDateTime.now();
+
+        String sql = "SELECT e.id, e.nombre, e.tipo, " +
+                "COALESCE((SELECT eh.cantidad_nueva FROM equipos_historial eh WHERE eh.equipo_id = e.id AND datetime(eh.fecha) <= datetime(?) ORDER BY datetime(eh.fecha) DESC, eh.id DESC LIMIT 1), " +
+                "        (SELECT eh.cantidad_nueva FROM equipos_historial eh WHERE eh.equipo_id = e.id ORDER BY datetime(eh.fecha) ASC, eh.id ASC LIMIT 1), " +
+                "        e.cantidad) AS cantidad_inicial, " +
+                "COALESCE((SELECT SUM(CASE WHEN eh.diferencia > 0 THEN eh.diferencia ELSE 0 END) FROM equipos_historial eh WHERE eh.equipo_id = e.id AND datetime(eh.fecha) >= datetime(?) AND datetime(eh.fecha) <= datetime(?)), 0) AS altas, " +
+                "COALESCE((SELECT SUM(CASE WHEN eh.diferencia < 0 THEN -eh.diferencia ELSE 0 END) FROM equipos_historial eh WHERE eh.equipo_id = e.id AND datetime(eh.fecha) >= datetime(?) AND datetime(eh.fecha) <= datetime(?)), 0) AS bajas, " +
+                "COALESCE((SELECT eh.cantidad_nueva FROM equipos_historial eh WHERE eh.equipo_id = e.id AND datetime(eh.fecha) <= datetime(?) ORDER BY datetime(eh.fecha) DESC, eh.id DESC LIMIT 1), " +
+                "        (SELECT eh.cantidad_nueva FROM equipos_historial eh WHERE eh.equipo_id = e.id ORDER BY datetime(eh.fecha) DESC, eh.id DESC LIMIT 1), " +
+                "        e.cantidad) AS cantidad_final " +
+                "FROM equipos e ORDER BY e.nombre";
+
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, formatDateTime(inicio));
+            stmt.setString(2, formatDateTime(inicio));
+            stmt.setString(3, formatDateTime(fin));
+            stmt.setString(4, formatDateTime(inicio));
+            stmt.setString(5, formatDateTime(fin));
+            stmt.setString(6, formatDateTime(fin));
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    EquipoResumen equipo = new EquipoResumen();
+                    equipo.setEquipoId(rs.getInt("id"));
+                    equipo.setNombre(rs.getString("nombre"));
+                    equipo.setTipo(rs.getString("tipo"));
+                    equipo.setCantidadInicial(rs.getInt("cantidad_inicial"));
+                    equipo.setAltas(rs.getInt("altas"));
+                    equipo.setBajas(rs.getInt("bajas"));
+                    equipo.setCantidadFinal(rs.getInt("cantidad_final"));
+                    resumen.add(equipo);
+                }
+            }
+        }
+
+        return resumen;
     }
 
     public static void eliminarEquipo(int equipoId) throws SQLException {

--- a/src/main/java/util/ReporteUtil.java
+++ b/src/main/java/util/ReporteUtil.java
@@ -15,6 +15,7 @@ import models.PagoDetalle;
 import models.Auditoria;
 import models.Pago;
 import models.ResumenTipo;
+import models.EquipoResumen;
 import util.AuditoriaFileUtil;
 import util.AuditoriaUtil;
 import java.io.InputStream;
@@ -288,6 +289,48 @@ public class ReporteUtil {
         } catch (Exception e) {
             System.err.println("❌ Error generando reporte de equipos: " + e.getMessage());
             throw new RuntimeException("Error generando reporte de equipos", e);
+        }
+    }
+
+    public static Path generarInformeEquiposPeriodo(LocalDate fechaInicio, LocalDate fechaFin, boolean mostrar) {
+        try (InputStream reporteStream = ReporteUtil.class.getResourceAsStream("/reports/equipos_resumen.jrxml")) {
+            if (reporteStream == null) {
+                System.err.println("❌ No se encontró el archivo equipos_resumen.jrxml");
+                return null;
+            }
+
+            List<EquipoResumen> datos = DatabaseUtil.obtenerResumenEquipos(fechaInicio, fechaFin);
+            if (datos.isEmpty()) {
+                System.out.println("⚠️ No se encontraron movimientos de equipos para el periodo seleccionado.");
+                return null;
+            }
+
+            Map<String, Object> parametros = new HashMap<>();
+            String periodoTexto = String.format("%s - %s",
+                    fechaInicio != null ? fechaInicio.format(FECHA_CORTA_FORMATTER) : "Inicio",
+                    fechaFin != null ? fechaFin.format(FECHA_CORTA_FORMATTER) : LocalDate.now().format(FECHA_CORTA_FORMATTER));
+            parametros.put("periodo", periodoTexto);
+            parametros.put("generadoEn", LocalDateTime.now().format(RESUMEN_FORMATTER));
+
+            JRBeanCollectionDataSource dataSource = new JRBeanCollectionDataSource(datos);
+            JasperReport jasperReport = JasperCompileManager.compileReport(reporteStream);
+            JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, parametros, dataSource);
+
+            if (mostrar) {
+                JasperViewer.viewReport(jasperPrint, false);
+            }
+
+            DateTimeFormatter formatterArchivo = DateTimeFormatter.BASIC_ISO_DATE;
+            String inicioArchivo = fechaInicio != null ? fechaInicio.format(formatterArchivo) : "INICIO";
+            String finArchivo = fechaFin != null ? fechaFin.format(formatterArchivo) : LocalDate.now().format(formatterArchivo);
+            String nombreArchivo = String.format("equipos_resumen_%s_%s.pdf", inicioArchivo, finArchivo);
+            Path destino = obtenerCarpetaDescargas().resolve(nombreArchivo);
+            JasperExportManager.exportReportToPdfFile(jasperPrint, destino.toString());
+            System.out.println("✅ Informe histórico de equipos generado en: " + destino);
+            return destino;
+        } catch (Exception e) {
+            System.err.println("❌ Error generando informe histórico de equipos: " + e.getMessage());
+            throw new RuntimeException("Error generando informe histórico de equipos", e);
         }
     }
 

--- a/src/main/resources/css/dashboard.css
+++ b/src/main/resources/css/dashboard.css
@@ -665,3 +665,21 @@
 .primary-button:hover {
     -fx-background-color: linear-gradient(to right, #2E8BFF, #4A6CF7);
 }
+
+.secondary-button {
+    -fx-background-color: transparent;
+    -fx-border-color: rgba(148, 163, 184, 0.6);
+    -fx-border-radius: 25;
+    -fx-background-radius: 25;
+    -fx-text-fill: rgba(255, 255, 255, 0.9);
+    -fx-font-weight: bold;
+    -fx-padding: 10 20;
+    -fx-font-size: 14px;
+    -fx-cursor: hand;
+    -fx-border-width: 1.4;
+}
+
+.secondary-button:hover {
+    -fx-border-color: rgba(78, 205, 196, 0.9);
+    -fx-text-fill: #4ECDC4;
+}

--- a/src/main/resources/fxml/equipos_admin.fxml
+++ b/src/main/resources/fxml/equipos_admin.fxml
@@ -30,6 +30,8 @@
                 <Region HBox.hgrow="ALWAYS"/>
                 <Button text="Generar reporte" onAction="#handleGenerarReporte"
                         styleClass="primary-button"/>
+                <Button text="Informe al momento" onAction="#handleGenerarInformeHistorico"
+                        styleClass="secondary-button"/>
             </HBox>
             <TableView fx:id="tablaEquipos" VBox.vgrow="ALWAYS"
                        style="-fx-background-radius: 16; -fx-table-cell-border-color: transparent; -fx-padding: 0;"

--- a/src/main/resources/reports/equipos_resumen.jrxml
+++ b/src/main/resources/reports/equipos_resumen.jrxml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd"
+              name="equipos_resumen" pageWidth="595" pageHeight="842" columnWidth="515"
+              leftMargin="40" rightMargin="40" topMargin="30" bottomMargin="30">
+    <parameter name="periodo" class="java.lang.String"/>
+    <parameter name="generadoEn" class="java.lang.String"/>
+    <field name="nombre" class="java.lang.String"/>
+    <field name="tipo" class="java.lang.String"/>
+    <field name="cantidadInicial" class="java.lang.Integer"/>
+    <field name="altas" class="java.lang.Integer"/>
+    <field name="bajas" class="java.lang.Integer"/>
+    <field name="cantidadFinal" class="java.lang.Integer"/>
+    <variable name="totalAltas" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{altas}]]></variableExpression>
+    </variable>
+    <variable name="totalBajas" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{bajas}]]></variableExpression>
+    </variable>
+    <variable name="totalFinal" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{cantidadFinal}]]></variableExpression>
+    </variable>
+    <title>
+        <band height="70">
+            <staticText>
+                <reportElement x="0" y="0" width="515" height="30"/>
+                <textElement textAlignment="Center">
+                    <font size="18" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Informe histórico de equipos]]></text>
+            </staticText>
+            <textField>
+                <reportElement x="0" y="35" width="515" height="18"/>
+                <textElement textAlignment="Center">
+                    <font size="12"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$P{periodo}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="0" y="53" width="515" height="14"/>
+                <textElement textAlignment="Center">
+                    <font size="9"/>
+                </textElement>
+                <textFieldExpression><![CDATA["Generado: " + $P{generadoEn}]]></textFieldExpression>
+            </textField>
+        </band>
+    </title>
+    <columnHeader>
+        <band height="22">
+            <staticText>
+                <reportElement x="0" y="0" width="160" height="22"/>
+                <textElement textAlignment="Left" verticalAlignment="Middle">
+                    <font isBold="true"/>
+                </textElement>
+                <text><![CDATA[Equipo]]></text>
+            </staticText>
+            <staticText>
+                <reportElement x="160" y="0" width="70" height="22"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
+                    <font isBold="true"/>
+                </textElement>
+                <text><![CDATA[Tipo]]></text>
+            </staticText>
+            <staticText>
+                <reportElement x="230" y="0" width="75" height="22"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
+                    <font isBold="true"/>
+                </textElement>
+                <text><![CDATA[Inicio]]></text>
+            </staticText>
+            <staticText>
+                <reportElement x="305" y="0" width="70" height="22"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
+                    <font isBold="true"/>
+                </textElement>
+                <text><![CDATA[Altas]]></text>
+            </staticText>
+            <staticText>
+                <reportElement x="375" y="0" width="70" height="22"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
+                    <font isBold="true"/>
+                </textElement>
+                <text><![CDATA[Bajas]]></text>
+            </staticText>
+            <staticText>
+                <reportElement x="445" y="0" width="70" height="22"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
+                    <font isBold="true"/>
+                </textElement>
+                <text><![CDATA[Final]]></text>
+            </staticText>
+        </band>
+    </columnHeader>
+    <detail>
+        <band height="20">
+            <textField>
+                <reportElement x="0" y="0" width="160" height="20"/>
+                <textElement verticalAlignment="Middle"/>
+                <textFieldExpression><![CDATA[$F{nombre}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="160" y="0" width="70" height="20"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle"/>
+                <textFieldExpression><![CDATA[$F{tipo}]]></textFieldExpression>
+            </textField>
+            <textField pattern="###">
+                <reportElement x="230" y="0" width="75" height="20"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle"/>
+                <textFieldExpression><![CDATA[$F{cantidadInicial}]]></textFieldExpression>
+            </textField>
+            <textField pattern="###">
+                <reportElement x="305" y="0" width="70" height="20"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle"/>
+                <textFieldExpression><![CDATA[$F{altas}]]></textFieldExpression>
+            </textField>
+            <textField pattern="###">
+                <reportElement x="375" y="0" width="70" height="20"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle"/>
+                <textFieldExpression><![CDATA[$F{bajas}]]></textFieldExpression>
+            </textField>
+            <textField pattern="###">
+                <reportElement x="445" y="0" width="70" height="20"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle"/>
+                <textFieldExpression><![CDATA[$F{cantidadFinal}]]></textFieldExpression>
+            </textField>
+        </band>
+    </detail>
+    <summary>
+        <band height="40">
+            <textField>
+                <reportElement x="0" y="10" width="515" height="16"/>
+                <textElement textAlignment="Center">
+                    <font size="11" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA["Total de equipos listados: " + $V{REPORT_COUNT}]]></textFieldExpression>
+            </textField>
+            <textField pattern="###">
+                <reportElement x="305" y="22" width="70" height="16"/>
+                <textElement textAlignment="Center"/>
+                <textFieldExpression><![CDATA[$V{totalAltas}]]></textFieldExpression>
+            </textField>
+            <textField pattern="###">
+                <reportElement x="375" y="22" width="70" height="16"/>
+                <textElement textAlignment="Center"/>
+                <textFieldExpression><![CDATA[$V{totalBajas}]]></textFieldExpression>
+            </textField>
+            <textField pattern="###">
+                <reportElement x="445" y="22" width="70" height="16"/>
+                <textElement textAlignment="Center"/>
+                <textFieldExpression><![CDATA[$V{totalFinal}]]></textFieldExpression>
+            </textField>
+        </band>
+    </summary>
+</jasperReport>


### PR DESCRIPTION
## Summary
- create a persistence layer for equipment inventory movements and expose helpers to retrieve aggregated balances
- capture quantity changes from the equipment admin UI, prompting for movement metadata and allowing on-demand historical report generation
- add a Jasper template and styling updates to export the new equipment summary PDF

## Testing
- `mvn -q -DskipTests package` *(fails: dependency download blocked by repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68daaca005a8832fb59f0a8bf8960d27