### PR TITLE
Enhance equipment history PDF styling and data

### DIFF
--- a/src/main/java/models/EquipoResumen.java
+++ b/src/main/java/models/EquipoResumen.java
@@ -8,11 +8,13 @@ public class EquipoResumen {
     private int altas;
     private int bajas;
     private int cantidadFinal;
+    private String fechaUltimoCambio;
 
     public EquipoResumen() {
     }
 
-    public EquipoResumen(int equipoId, String nombre, String tipo, int cantidadInicial, int altas, int bajas, int cantidadFinal) {
+    public EquipoResumen(int equipoId, String nombre, String tipo, int cantidadInicial, int altas, int bajas, int cantidadFinal,
+                         String fechaUltimoCambio) {
         this.equipoId = equipoId;
         this.nombre = nombre;
         this.tipo = tipo;
@@ -20,6 +22,7 @@ public class EquipoResumen {
         this.altas = altas;
         this.bajas = bajas;
         this.cantidadFinal = cantidadFinal;
+        this.fechaUltimoCambio = fechaUltimoCambio;
     }
 
     public int getEquipoId() {
@@ -76,5 +79,17 @@ public class EquipoResumen {
 
     public void setCantidadFinal(int cantidadFinal) {
         this.cantidadFinal = cantidadFinal;
+    }
+
+    public int getVariacion() {
+        return altas - bajas;
+    }
+
+    public String getFechaUltimoCambio() {
+        return fechaUltimoCambio;
+    }
+
+    public void setFechaUltimoCambio(String fechaUltimoCambio) {
+        this.fechaUltimoCambio = fechaUltimoCambio;
     }
 }

--- a/src/main/java/util/DatabaseUtil.java
+++ b/src/main/java/util/DatabaseUtil.java
@@ -36,6 +36,8 @@ public class DatabaseUtil {
     private static final int BUSY_TIMEOUT_MS = 60000;
     private static final DateTimeFormatter SQLITE_DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final Pattern PAGO_ID_PATTERN = Pattern.compile("Pago\\s+(\\d+)", Pattern.CASE_INSENSITIVE);
+    private static final DateTimeFormatter REPORTE_FECHA_HORA_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+    private static final String TEXTO_SIN_MOVIMIENTOS = "-";
 
     public static Connection getConnection() throws SQLException {
         Connection conn = DriverManager.getConnection(URL);
@@ -1216,7 +1218,9 @@ public class DatabaseUtil {
                 "COALESCE((SELECT SUM(CASE WHEN eh.diferencia < 0 THEN -eh.diferencia ELSE 0 END) FROM equipos_historial eh WHERE eh.equipo_id = e.id AND datetime(eh.fecha) >= datetime(?) AND datetime(eh.fecha) <= datetime(?)), 0) AS bajas, " +
                 "COALESCE((SELECT eh.cantidad_nueva FROM equipos_historial eh WHERE eh.equipo_id = e.id AND datetime(eh.fecha) <= datetime(?) ORDER BY datetime(eh.fecha) DESC, eh.id DESC LIMIT 1), " +
                 "        (SELECT eh.cantidad_nueva FROM equipos_historial eh WHERE eh.equipo_id = e.id ORDER BY datetime(eh.fecha) DESC, eh.id DESC LIMIT 1), " +
-                "        e.cantidad) AS cantidad_final " +
+                "        e.cantidad) AS cantidad_final, " +
+                "COALESCE((SELECT eh.fecha FROM equipos_historial eh WHERE eh.equipo_id = e.id AND datetime(eh.fecha) >= datetime(?) AND datetime(eh.fecha) <= datetime(?) ORDER BY datetime(eh.fecha) DESC, eh.id DESC LIMIT 1), " +
+                "        (SELECT eh.fecha FROM equipos_historial eh WHERE eh.equipo_id = e.id ORDER BY datetime(eh.fecha) DESC, eh.id DESC LIMIT 1)) AS fecha_ultimo_cambio " +
                 "FROM equipos e ORDER BY e.nombre";
 
         try (Connection conn = getConnection();
@@ -1227,6 +1231,8 @@ public class DatabaseUtil {
             stmt.setString(4, formatDateTime(inicio));
             stmt.setString(5, formatDateTime(fin));
             stmt.setString(6, formatDateTime(fin));
+            stmt.setString(7, formatDateTime(inicio));
+            stmt.setString(8, formatDateTime(fin));
 
             try (ResultSet rs = stmt.executeQuery()) {
                 while (rs.next()) {
@@ -1238,6 +1244,7 @@ public class DatabaseUtil {
                     equipo.setAltas(rs.getInt("altas"));
                     equipo.setBajas(rs.getInt("bajas"));
                     equipo.setCantidadFinal(rs.getInt("cantidad_final"));
+                    equipo.setFechaUltimoCambio(formatDateTimeForReport(rs.getString("fecha_ultimo_cambio")));
                     resumen.add(equipo);
                 }
             }
@@ -2542,6 +2549,14 @@ public class DatabaseUtil {
                 return null;
             }
         }
+    }
+
+    private static String formatDateTimeForReport(String valor) {
+        LocalDateTime fecha = parseDateTime(valor);
+        if (fecha == null) {
+            return TEXTO_SIN_MOVIMIENTOS;
+        }
+        return fecha.format(REPORTE_FECHA_HORA_FORMATTER);
     }
 
     private static LocalDate parseFecha(String valor) {

--- a/src/main/resources/reports/equipos_resumen.jrxml
+++ b/src/main/resources/reports/equipos_resumen.jrxml
@@ -4,6 +4,48 @@
               xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd"
               name="equipos_resumen" pageWidth="595" pageHeight="842" columnWidth="515"
               leftMargin="40" rightMargin="40" topMargin="30" bottomMargin="30">
+    <property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
+    <property name="net.sf.jasperreports.print.keep.full.text" value="true"/>
+    <style name="Base" isDefault="true">
+        <font fontName="Helvetica" size="9"/>
+        <paragraph lineSpacing="1.2"/>
+    </style>
+    <style name="Title" parent="Base" forecolor="#FFFFFF">
+        <font size="22" isBold="true"/>
+    </style>
+    <style name="Subtitle" parent="Base" forecolor="#E8EDFF">
+        <font size="11"/>
+    </style>
+    <style name="InfoChip" parent="Base" mode="Opaque" forecolor="#1A237E" backcolor="#E8EAF6">
+        <box>
+            <pen lineWidth="0"/>
+            <topPen lineWidth="0"/>
+            <leftPen lineWidth="0"/>
+            <bottomPen lineWidth="0"/>
+            <rightPen lineWidth="0"/>
+        </box>
+        <font size="9" isBold="true"/>
+        <paragraph leftIndent="6" rightIndent="6"/>
+    </style>
+    <style name="ColumnHeader" parent="Base" mode="Opaque" backcolor="#1A237E" forecolor="#FFFFFF">
+        <box>
+            <pen lineWidth="0"/>
+        </box>
+        <font size="9" isBold="true"/>
+    </style>
+    <style name="DetailText" parent="Base" forecolor="#1F2933">
+        <box>
+            <pen lineWidth="0"/>
+        </box>
+        <font size="9"/>
+    </style>
+    <style name="DetailNumber" parent="DetailText"/>
+    <style name="SummaryLabel" parent="Base" forecolor="#64748B">
+        <font size="9" isBold="true"/>
+    </style>
+    <style name="SummaryValue" parent="Base" forecolor="#1A237E">
+        <font size="16" isBold="true"/>
+    </style>
     <parameter name="periodo" class="java.lang.String"/>
     <parameter name="generadoEn" class="java.lang.String"/>
     <field name="nombre" class="java.lang.String"/>
@@ -12,144 +54,254 @@
     <field name="altas" class="java.lang.Integer"/>
     <field name="bajas" class="java.lang.Integer"/>
     <field name="cantidadFinal" class="java.lang.Integer"/>
+    <field name="variacion" class="java.lang.Integer"/>
+    <field name="fechaUltimoCambio" class="java.lang.String"/>
     <variable name="totalAltas" class="java.lang.Integer" calculation="Sum">
         <variableExpression><![CDATA[$F{altas}]]></variableExpression>
     </variable>
     <variable name="totalBajas" class="java.lang.Integer" calculation="Sum">
         <variableExpression><![CDATA[$F{bajas}]]></variableExpression>
     </variable>
+    <variable name="totalVariacion" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{variacion}]]></variableExpression>
+    </variable>
     <variable name="totalFinal" class="java.lang.Integer" calculation="Sum">
         <variableExpression><![CDATA[$F{cantidadFinal}]]></variableExpression>
     </variable>
     <title>
-        <band height="70">
+        <band height="120">
+            <rectangle>
+                <reportElement x="0" y="0" width="515" height="78" mode="Opaque" backcolor="#1A237E" radius="16"/>
+                <graphicElement>
+                    <pen lineWidth="0"/>
+                </graphicElement>
+            </rectangle>
             <staticText>
-                <reportElement x="0" y="0" width="515" height="30"/>
-                <textElement textAlignment="Center">
-                    <font size="18" isBold="true"/>
-                </textElement>
+                <reportElement x="24" y="12" width="467" height="28" style="Title"/>
                 <text><![CDATA[Informe histórico de equipos]]></text>
             </staticText>
             <textField>
-                <reportElement x="0" y="35" width="515" height="18"/>
-                <textElement textAlignment="Center">
-                    <font size="12"/>
-                </textElement>
+                <reportElement x="24" y="44" width="467" height="16" style="Subtitle"/>
                 <textFieldExpression><![CDATA[$P{periodo}]]></textFieldExpression>
             </textField>
             <textField>
-                <reportElement x="0" y="53" width="515" height="14"/>
-                <textElement textAlignment="Center">
-                    <font size="9"/>
-                </textElement>
-                <textFieldExpression><![CDATA["Generado: " + $P{generadoEn}]]></textFieldExpression>
+                <reportElement x="24" y="62" width="467" height="14" style="Subtitle"/>
+                <textFieldExpression><![CDATA["Generado el " + $P{generadoEn}]]></textFieldExpression>
             </textField>
+            <frame>
+                <reportElement x="0" y="88" width="515" height="24"/>
+                <rectangle>
+                    <reportElement x="0" y="0" width="515" height="24" mode="Opaque" backcolor="#E8EAF6" radius="12"/>
+                    <graphicElement>
+                        <pen lineWidth="0"/>
+                    </graphicElement>
+                </rectangle>
+                <staticText>
+                    <reportElement x="12" y="4" width="491" height="16" style="InfoChip"/>
+                    <text><![CDATA[Resumen de movimientos y existencias de equipos registrados]]></text>
+                </staticText>
+            </frame>
         </band>
     </title>
     <columnHeader>
-        <band height="22">
+        <band height="32">
+            <rectangle>
+                <reportElement x="0" y="0" width="515" height="32" style="ColumnHeader" radius="12"/>
+                <graphicElement>
+                    <pen lineWidth="0"/>
+                </graphicElement>
+            </rectangle>
             <staticText>
-                <reportElement x="0" y="0" width="160" height="22"/>
-                <textElement textAlignment="Left" verticalAlignment="Middle">
-                    <font isBold="true"/>
+                <reportElement x="0" y="6" width="125" height="20" forecolor="#FFFFFF"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="9" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Equipo]]></text>
             </staticText>
             <staticText>
-                <reportElement x="160" y="0" width="70" height="22"/>
+                <reportElement x="125" y="6" width="50" height="20" forecolor="#FFFFFF"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font isBold="true"/>
+                    <font size="9" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Tipo]]></text>
             </staticText>
             <staticText>
-                <reportElement x="230" y="0" width="75" height="22"/>
+                <reportElement x="175" y="6" width="55" height="20" forecolor="#FFFFFF"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font isBold="true"/>
+                    <font size="9" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Inicio]]></text>
             </staticText>
             <staticText>
-                <reportElement x="305" y="0" width="70" height="22"/>
+                <reportElement x="230" y="6" width="55" height="20" forecolor="#FFFFFF"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font isBold="true"/>
+                    <font size="9" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Altas]]></text>
             </staticText>
             <staticText>
-                <reportElement x="375" y="0" width="70" height="22"/>
+                <reportElement x="285" y="6" width="55" height="20" forecolor="#FFFFFF"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font isBold="true"/>
+                    <font size="9" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Bajas]]></text>
             </staticText>
             <staticText>
-                <reportElement x="445" y="0" width="70" height="22"/>
+                <reportElement x="340" y="6" width="55" height="20" forecolor="#FFFFFF"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font isBold="true"/>
+                    <font size="9" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Variación]]></text>
+            </staticText>
+            <staticText>
+                <reportElement x="395" y="6" width="55" height="20" forecolor="#FFFFFF"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
+                    <font size="9" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Final]]></text>
+            </staticText>
+            <staticText>
+                <reportElement x="450" y="6" width="65" height="20" forecolor="#FFFFFF"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
+                    <font size="9" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Ult. cambio]]></text>
             </staticText>
         </band>
     </columnHeader>
     <detail>
-        <band height="20">
-            <textField>
-                <reportElement x="0" y="0" width="160" height="20"/>
+        <band height="26">
+            <textField isStretchWithOverflow="true">
+                <reportElement x="0" y="4" width="125" height="18" style="DetailText"/>
                 <textElement verticalAlignment="Middle"/>
                 <textFieldExpression><![CDATA[$F{nombre}]]></textFieldExpression>
             </textField>
             <textField>
-                <reportElement x="160" y="0" width="70" height="20"/>
+                <reportElement x="125" y="4" width="50" height="18" style="DetailNumber"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle"/>
                 <textFieldExpression><![CDATA[$F{tipo}]]></textFieldExpression>
             </textField>
             <textField pattern="###">
-                <reportElement x="230" y="0" width="75" height="20"/>
+                <reportElement x="175" y="4" width="55" height="18" style="DetailNumber"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle"/>
                 <textFieldExpression><![CDATA[$F{cantidadInicial}]]></textFieldExpression>
             </textField>
             <textField pattern="###">
-                <reportElement x="305" y="0" width="70" height="20"/>
+                <reportElement x="230" y="4" width="55" height="18" style="DetailNumber"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle"/>
                 <textFieldExpression><![CDATA[$F{altas}]]></textFieldExpression>
             </textField>
             <textField pattern="###">
-                <reportElement x="375" y="0" width="70" height="20"/>
+                <reportElement x="285" y="4" width="55" height="18" style="DetailNumber"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle"/>
                 <textFieldExpression><![CDATA[$F{bajas}]]></textFieldExpression>
             </textField>
+            <textField pattern="+#;-#;0">
+                <reportElement x="340" y="4" width="55" height="18" style="DetailNumber"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle"/>
+                <textFieldExpression><![CDATA[$F{variacion}]]></textFieldExpression>
+            </textField>
             <textField pattern="###">
-                <reportElement x="445" y="0" width="70" height="20"/>
+                <reportElement x="395" y="4" width="55" height="18" style="DetailNumber"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle"/>
                 <textFieldExpression><![CDATA[$F{cantidadFinal}]]></textFieldExpression>
             </textField>
+            <textField>
+                <reportElement x="450" y="4" width="65" height="18" style="DetailNumber"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle"/>
+                <textFieldExpression><![CDATA[$F{fechaUltimoCambio}]]></textFieldExpression>
+            </textField>
+            <line>
+                <reportElement x="0" y="24" width="515" height="1" forecolor="#E2E8F0"/>
+            </line>
         </band>
     </detail>
     <summary>
-        <band height="40">
+        <band height="120">
             <textField>
-                <reportElement x="0" y="10" width="515" height="16"/>
+                <reportElement x="0" y="4" width="515" height="18" forecolor="#1A237E"/>
                 <textElement textAlignment="Center">
-                    <font size="11" isBold="true"/>
+                    <font size="12" isBold="true"/>
                 </textElement>
                 <textFieldExpression><![CDATA["Total de equipos listados: " + $V{REPORT_COUNT}]]></textFieldExpression>
             </textField>
-            <textField pattern="###">
-                <reportElement x="305" y="22" width="70" height="16"/>
-                <textElement textAlignment="Center"/>
-                <textFieldExpression><![CDATA[$V{totalAltas}]]></textFieldExpression>
-            </textField>
-            <textField pattern="###">
-                <reportElement x="375" y="22" width="70" height="16"/>
-                <textElement textAlignment="Center"/>
-                <textFieldExpression><![CDATA[$V{totalBajas}]]></textFieldExpression>
-            </textField>
-            <textField pattern="###">
-                <reportElement x="445" y="22" width="70" height="16"/>
-                <textElement textAlignment="Center"/>
-                <textFieldExpression><![CDATA[$V{totalFinal}]]></textFieldExpression>
-            </textField>
+            <frame>
+                <reportElement x="0" y="32" width="515" height="76"/>
+                <rectangle>
+                    <reportElement x="0" y="0" width="515" height="76" mode="Opaque" backcolor="#EEF2FF" radius="16"/>
+                    <graphicElement>
+                        <pen lineWidth="0"/>
+                    </graphicElement>
+                </rectangle>
+                <frame>
+                    <reportElement x="18" y="12" width="120" height="52"/>
+                    <rectangle>
+                        <reportElement x="0" y="0" width="120" height="52" mode="Opaque" backcolor="#FFFFFF" radius="14"/>
+                        <graphicElement>
+                            <pen lineWidth="1" lineColor="#C7D2FE"/>
+                        </graphicElement>
+                    </rectangle>
+                    <staticText>
+                        <reportElement x="12" y="8" width="96" height="12" style="SummaryLabel"/>
+                        <text><![CDATA[ALTAS]]></text>
+                    </staticText>
+                    <textField pattern="###">
+                        <reportElement x="12" y="24" width="96" height="20" style="SummaryValue"/>
+                        <textFieldExpression><![CDATA[$V{totalAltas}]]></textFieldExpression>
+                    </textField>
+                </frame>
+                <frame>
+                    <reportElement x="148" y="12" width="120" height="52"/>
+                    <rectangle>
+                        <reportElement x="0" y="0" width="120" height="52" mode="Opaque" backcolor="#FFFFFF" radius="14"/>
+                        <graphicElement>
+                            <pen lineWidth="1" lineColor="#FECACA"/>
+                        </graphicElement>
+                    </rectangle>
+                    <staticText>
+                        <reportElement x="12" y="8" width="96" height="12" style="SummaryLabel"/>
+                        <text><![CDATA[BAJAS]]></text>
+                    </staticText>
+                    <textField pattern="###">
+                        <reportElement x="12" y="24" width="96" height="20" style="SummaryValue" forecolor="#B91C1C"/>
+                        <textFieldExpression><![CDATA[$V{totalBajas}]]></textFieldExpression>
+                    </textField>
+                </frame>
+                <frame>
+                    <reportElement x="278" y="12" width="120" height="52"/>
+                    <rectangle>
+                        <reportElement x="0" y="0" width="120" height="52" mode="Opaque" backcolor="#FFFFFF" radius="14"/>
+                        <graphicElement>
+                            <pen lineWidth="1" lineColor="#BBF7D0"/>
+                        </graphicElement>
+                    </rectangle>
+                    <staticText>
+                        <reportElement x="12" y="8" width="96" height="12" style="SummaryLabel"/>
+                        <text><![CDATA[VARIACIÓN NETA]]></text>
+                    </staticText>
+                    <textField pattern="+#;-#;0">
+                        <reportElement x="12" y="24" width="96" height="20" style="SummaryValue"/>
+                        <textFieldExpression><![CDATA[$V{totalVariacion}]]></textFieldExpression>
+                    </textField>
+                </frame>
+                <frame>
+                    <reportElement x="408" y="12" width="120" height="52"/>
+                    <rectangle>
+                        <reportElement x="0" y="0" width="120" height="52" mode="Opaque" backcolor="#FFFFFF" radius="14"/>
+                        <graphicElement>
+                            <pen lineWidth="1" lineColor="#BFDBFE"/>
+                        </graphicElement>
+                    </rectangle>
+                    <staticText>
+                        <reportElement x="12" y="8" width="96" height="12" style="SummaryLabel"/>
+                        <text><![CDATA[STOCK FINAL]]></text>
+                    </staticText>
+                    <textField pattern="###">
+                        <reportElement x="12" y="24" width="96" height="20" style="SummaryValue"/>
+                        <textFieldExpression><![CDATA[$V{totalFinal}]]></textFieldExpression>
+                    </textField>
+                </frame>
+            </frame>
         </band>
     </summary>
 </jasperReport>


### PR DESCRIPTION
## Summary
- extend the equipment summary model and query to expose the last change timestamp and a net variation value
- format movement dates for reporting and provide a fallback when no history exists
- refresh the equipos_resumen Jasper template with a more vibrant layout, a variation column, and highlighted totals

## Testing
- mvn -q -DskipTests package *(fails: Maven Central returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68dab22cc3d0832f96cec0d2a5ee61ad