### PR TITLE
Actualizar informe histórico de equipos con diseño financiero

### DIFF
--- a/src/main/java/models/EquipoResumen.java
+++ b/src/main/java/models/EquipoResumen.java
@@ -1,6 +1,9 @@
 package models;
 
 public class EquipoResumen {
+    private static final java.time.format.DateTimeFormatter FORMATO_REPORTE =
+            java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm", new java.util.Locale("es", "ES"));
+
     private int equipoId;
     private String nombre;
     private String tipo;
@@ -8,6 +11,7 @@ public class EquipoResumen {
     private int altas;
     private int bajas;
     private int cantidadFinal;
+    private java.time.LocalDateTime ultimaActualizacion;
 
     public EquipoResumen() {
     }
@@ -76,5 +80,17 @@ public class EquipoResumen {
 
     public void setCantidadFinal(int cantidadFinal) {
         this.cantidadFinal = cantidadFinal;
+    }
+
+    public java.time.LocalDateTime getUltimaActualizacion() {
+        return ultimaActualizacion;
+    }
+
+    public void setUltimaActualizacion(java.time.LocalDateTime ultimaActualizacion) {
+        this.ultimaActualizacion = ultimaActualizacion;
+    }
+
+    public String getUltimaActualizacionFormateada() {
+        return ultimaActualizacion == null ? "-" : ultimaActualizacion.format(FORMATO_REPORTE);
     }
 }

--- a/src/main/java/util/DatabaseUtil.java
+++ b/src/main/java/util/DatabaseUtil.java
@@ -1216,7 +1216,9 @@ public class DatabaseUtil {
                 "COALESCE((SELECT SUM(CASE WHEN eh.diferencia < 0 THEN -eh.diferencia ELSE 0 END) FROM equipos_historial eh WHERE eh.equipo_id = e.id AND datetime(eh.fecha) >= datetime(?) AND datetime(eh.fecha) <= datetime(?)), 0) AS bajas, " +
                 "COALESCE((SELECT eh.cantidad_nueva FROM equipos_historial eh WHERE eh.equipo_id = e.id AND datetime(eh.fecha) <= datetime(?) ORDER BY datetime(eh.fecha) DESC, eh.id DESC LIMIT 1), " +
                 "        (SELECT eh.cantidad_nueva FROM equipos_historial eh WHERE eh.equipo_id = e.id ORDER BY datetime(eh.fecha) DESC, eh.id DESC LIMIT 1), " +
-                "        e.cantidad) AS cantidad_final " +
+                "        e.cantidad) AS cantidad_final, " +
+                "(SELECT eh.fecha FROM equipos_historial eh WHERE eh.equipo_id = e.id AND datetime(eh.fecha) >= datetime(?) AND datetime(eh.fecha) <= datetime(?) ORDER BY datetime(eh.fecha) DESC, eh.id DESC LIMIT 1) AS ultima_actualizacion_periodo, " +
+                "(SELECT eh.fecha FROM equipos_historial eh WHERE eh.equipo_id = e.id ORDER BY datetime(eh.fecha) DESC, eh.id DESC LIMIT 1) AS ultima_actualizacion_global " +
                 "FROM equipos e ORDER BY e.nombre";
 
         try (Connection conn = getConnection();
@@ -1227,6 +1229,8 @@ public class DatabaseUtil {
             stmt.setString(4, formatDateTime(inicio));
             stmt.setString(5, formatDateTime(fin));
             stmt.setString(6, formatDateTime(fin));
+            stmt.setString(7, formatDateTime(inicio));
+            stmt.setString(8, formatDateTime(fin));
 
             try (ResultSet rs = stmt.executeQuery()) {
                 while (rs.next()) {
@@ -1238,6 +1242,10 @@ public class DatabaseUtil {
                     equipo.setAltas(rs.getInt("altas"));
                     equipo.setBajas(rs.getInt("bajas"));
                     equipo.setCantidadFinal(rs.getInt("cantidad_final"));
+                    String ultimaPeriodo = rs.getString("ultima_actualizacion_periodo");
+                    String ultimaGlobal = rs.getString("ultima_actualizacion_global");
+                    LocalDateTime ultima = ultimaPeriodo != null ? parseDateTime(ultimaPeriodo) : parseDateTime(ultimaGlobal);
+                    equipo.setUltimaActualizacion(ultima);
                     resumen.add(equipo);
                 }
             }

--- a/src/main/resources/reports/equipos_resumen.jrxml
+++ b/src/main/resources/reports/equipos_resumen.jrxml
@@ -1,17 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd"
-              name="equipos_resumen" pageWidth="595" pageHeight="842" columnWidth="515"
-              leftMargin="40" rightMargin="40" topMargin="30" bottomMargin="30">
+<jasperReport
+        xmlns="http://jasperreports.sourceforge.net/jasperreports"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd"
+        name="equipos_resumen"
+        language="java"
+        pageWidth="595"
+        pageHeight="842"
+        columnWidth="555"
+        leftMargin="20"
+        rightMargin="20"
+        topMargin="20"
+        bottomMargin="20"
+        whenNoDataType="AllSectionsNoDetail"
+        uuid="f0c6a5e0-32ac-4a2b-9884-6cf686c92b55">
+
     <parameter name="periodo" class="java.lang.String"/>
     <parameter name="generadoEn" class="java.lang.String"/>
+
     <field name="nombre" class="java.lang.String"/>
     <field name="tipo" class="java.lang.String"/>
     <field name="cantidadInicial" class="java.lang.Integer"/>
     <field name="altas" class="java.lang.Integer"/>
     <field name="bajas" class="java.lang.Integer"/>
     <field name="cantidadFinal" class="java.lang.Integer"/>
+    <field name="ultimaActualizacionFormateada" class="java.lang.String"/>
+
+    <variable name="totalInicial" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{cantidadInicial}]]></variableExpression>
+    </variable>
     <variable name="totalAltas" class="java.lang.Integer" calculation="Sum">
         <variableExpression><![CDATA[$F{altas}]]></variableExpression>
     </variable>
@@ -21,133 +38,240 @@
     <variable name="totalFinal" class="java.lang.Integer" calculation="Sum">
         <variableExpression><![CDATA[$F{cantidadFinal}]]></variableExpression>
     </variable>
+
     <title>
-        <band height="70">
-            <staticText>
-                <reportElement x="0" y="0" width="515" height="30"/>
-                <textElement textAlignment="Center">
-                    <font size="18" isBold="true"/>
-                </textElement>
-                <text><![CDATA[Informe histórico de equipos]]></text>
-            </staticText>
+        <band height="100">
+            <rectangle>
+                <reportElement x="0" y="0" width="555" height="100" backcolor="#3F51B5" mode="Opaque"/>
+            </rectangle>
             <textField>
-                <reportElement x="0" y="35" width="515" height="18"/>
-                <textElement textAlignment="Center">
+                <reportElement x="0" y="20" width="555" height="30" forecolor="#FFFFFF"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
+                    <font size="22" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA["Informe histórico de equipos"]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="0" y="55" width="555" height="20" forecolor="#FFFFFF"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
                     <font size="12"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$P{periodo}]]></textFieldExpression>
             </textField>
             <textField>
-                <reportElement x="0" y="53" width="515" height="14"/>
-                <textElement textAlignment="Center">
-                    <font size="9"/>
+                <reportElement x="0" y="75" width="555" height="20" forecolor="#FFFFFF"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
+                    <font size="10"/>
                 </textElement>
                 <textFieldExpression><![CDATA["Generado: " + $P{generadoEn}]]></textFieldExpression>
             </textField>
         </band>
     </title>
+
+    <pageHeader>
+        <band height="12">
+            <line>
+                <reportElement x="0" y="10" width="555" height="1" forecolor="#E0E0E0"/>
+            </line>
+        </band>
+    </pageHeader>
+
     <columnHeader>
-        <band height="22">
+        <band height="32">
             <staticText>
-                <reportElement x="0" y="0" width="160" height="22"/>
-                <textElement textAlignment="Left" verticalAlignment="Middle">
-                    <font isBold="true"/>
+                <reportElement x="0" y="0" width="160" height="32" backcolor="#3F51B5" forecolor="#FFFFFF" mode="Opaque"/>
+                <textElement verticalAlignment="Middle">
+                    <font size="11" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Equipo]]></text>
             </staticText>
             <staticText>
-                <reportElement x="160" y="0" width="70" height="22"/>
+                <reportElement x="160" y="0" width="75" height="32" backcolor="#3F51B5" forecolor="#FFFFFF" mode="Opaque"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font isBold="true"/>
+                    <font size="11" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Tipo]]></text>
             </staticText>
             <staticText>
-                <reportElement x="230" y="0" width="75" height="22"/>
+                <reportElement x="235" y="0" width="55" height="32" backcolor="#3F51B5" forecolor="#FFFFFF" mode="Opaque"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font isBold="true"/>
+                    <font size="11" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Inicio]]></text>
             </staticText>
             <staticText>
-                <reportElement x="305" y="0" width="70" height="22"/>
+                <reportElement x="290" y="0" width="55" height="32" backcolor="#3F51B5" forecolor="#FFFFFF" mode="Opaque"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font isBold="true"/>
+                    <font size="11" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Altas]]></text>
             </staticText>
             <staticText>
-                <reportElement x="375" y="0" width="70" height="22"/>
+                <reportElement x="345" y="0" width="55" height="32" backcolor="#3F51B5" forecolor="#FFFFFF" mode="Opaque"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font isBold="true"/>
+                    <font size="11" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Bajas]]></text>
             </staticText>
             <staticText>
-                <reportElement x="445" y="0" width="70" height="22"/>
+                <reportElement x="400" y="0" width="55" height="32" backcolor="#3F51B5" forecolor="#FFFFFF" mode="Opaque"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle">
-                    <font isBold="true"/>
+                    <font size="11" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Final]]></text>
             </staticText>
+            <staticText>
+                <reportElement x="455" y="0" width="100" height="32" backcolor="#3F51B5" forecolor="#FFFFFF" mode="Opaque"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
+                    <font size="11" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Último movimiento]]></text>
+            </staticText>
         </band>
     </columnHeader>
+
     <detail>
-        <band height="20">
+        <band height="24" splitType="Stretch">
             <textField>
-                <reportElement x="0" y="0" width="160" height="20"/>
+                <reportElement x="0" y="0" width="160" height="24"/>
                 <textElement verticalAlignment="Middle"/>
                 <textFieldExpression><![CDATA[$F{nombre}]]></textFieldExpression>
             </textField>
             <textField>
-                <reportElement x="160" y="0" width="70" height="20"/>
+                <reportElement x="160" y="0" width="75" height="24"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle"/>
                 <textFieldExpression><![CDATA[$F{tipo}]]></textFieldExpression>
             </textField>
             <textField pattern="###">
-                <reportElement x="230" y="0" width="75" height="20"/>
+                <reportElement x="235" y="0" width="55" height="24"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle"/>
                 <textFieldExpression><![CDATA[$F{cantidadInicial}]]></textFieldExpression>
             </textField>
             <textField pattern="###">
-                <reportElement x="305" y="0" width="70" height="20"/>
+                <reportElement x="290" y="0" width="55" height="24"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle"/>
                 <textFieldExpression><![CDATA[$F{altas}]]></textFieldExpression>
             </textField>
             <textField pattern="###">
-                <reportElement x="375" y="0" width="70" height="20"/>
+                <reportElement x="345" y="0" width="55" height="24"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle"/>
                 <textFieldExpression><![CDATA[$F{bajas}]]></textFieldExpression>
             </textField>
             <textField pattern="###">
-                <reportElement x="445" y="0" width="70" height="20"/>
+                <reportElement x="400" y="0" width="55" height="24"/>
                 <textElement textAlignment="Center" verticalAlignment="Middle"/>
                 <textFieldExpression><![CDATA[$F{cantidadFinal}]]></textFieldExpression>
             </textField>
+            <textField>
+                <reportElement x="455" y="0" width="100" height="24"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle"/>
+                <textFieldExpression><![CDATA[$F{ultimaActualizacionFormateada}]]></textFieldExpression>
+            </textField>
+            <line>
+                <reportElement x="0" y="23" width="555" height="1" forecolor="#E0E0E0"/>
+            </line>
         </band>
     </detail>
-    <summary>
-        <band height="40">
+
+    <pageFooter>
+        <band height="30">
             <textField>
-                <reportElement x="0" y="10" width="515" height="16"/>
-                <textElement textAlignment="Center">
-                    <font size="11" isBold="true"/>
-                </textElement>
-                <textFieldExpression><![CDATA["Total de equipos listados: " + $V{REPORT_COUNT}]]></textFieldExpression>
+                <reportElement x="0" y="10" width="555" height="20"/>
+                <textElement textAlignment="Right" verticalAlignment="Middle"/>
+                <textFieldExpression><![CDATA["Página " + $V{PAGE_NUMBER} + " de " + $V{PAGE_COUNT}]]></textFieldExpression>
             </textField>
+        </band>
+    </pageFooter>
+
+    <summary>
+        <band height="200">
+            <staticText>
+                <reportElement x="0" y="10" width="555" height="25" forecolor="#3F51B5"/>
+                <textElement textAlignment="Center">
+                    <font size="14" isBold="true"/>
+                </textElement>
+                <text><![CDATA[RESUMEN DE MOVIMIENTOS]]></text>
+            </staticText>
+
+            <rectangle>
+                <reportElement x="40" y="45" width="475" height="130" backcolor="#F9F9F9" mode="Opaque"/>
+                <graphicElement>
+                    <pen lineWidth="0.5" lineColor="#E0E0E0"/>
+                </graphicElement>
+            </rectangle>
+
+            <staticText>
+                <reportElement x="60" y="60" width="220" height="20"/>
+                <textElement textAlignment="Left">
+                    <font size="12"/>
+                </textElement>
+                <text><![CDATA[Total de equipos listados:]]></text>
+            </staticText>
             <textField pattern="###">
-                <reportElement x="305" y="22" width="70" height="16"/>
-                <textElement textAlignment="Center"/>
+                <reportElement x="320" y="60" width="150" height="20"/>
+                <textElement textAlignment="Right">
+                    <font size="12" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{REPORT_COUNT}]]></textFieldExpression>
+            </textField>
+
+            <staticText>
+                <reportElement x="60" y="85" width="220" height="20"/>
+                <textElement textAlignment="Left">
+                    <font size="12"/>
+                </textElement>
+                <text><![CDATA[Inventario inicial total:]]></text>
+            </staticText>
+            <textField pattern="###">
+                <reportElement x="320" y="85" width="150" height="20"/>
+                <textElement textAlignment="Right">
+                    <font size="12"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{totalInicial}]]></textFieldExpression>
+            </textField>
+
+            <staticText>
+                <reportElement x="60" y="110" width="220" height="20"/>
+                <textElement textAlignment="Left">
+                    <font size="12"/>
+                </textElement>
+                <text><![CDATA[Altas registradas:]]></text>
+            </staticText>
+            <textField pattern="###">
+                <reportElement x="320" y="110" width="150" height="20"/>
+                <textElement textAlignment="Right">
+                    <font size="12"/>
+                </textElement>
                 <textFieldExpression><![CDATA[$V{totalAltas}]]></textFieldExpression>
             </textField>
+
+            <staticText>
+                <reportElement x="60" y="135" width="220" height="20"/>
+                <textElement textAlignment="Left">
+                    <font size="12"/>
+                </textElement>
+                <text><![CDATA[Bajas registradas:]]></text>
+            </staticText>
             <textField pattern="###">
-                <reportElement x="375" y="22" width="70" height="16"/>
-                <textElement textAlignment="Center"/>
+                <reportElement x="320" y="135" width="150" height="20"/>
+                <textElement textAlignment="Right">
+                    <font size="12"/>
+                </textElement>
                 <textFieldExpression><![CDATA[$V{totalBajas}]]></textFieldExpression>
             </textField>
+
+            <staticText>
+                <reportElement x="60" y="160" width="220" height="20"/>
+                <textElement textAlignment="Left">
+                    <font size="12" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Stock final total:]]></text>
+            </staticText>
             <textField pattern="###">
-                <reportElement x="445" y="22" width="70" height="16"/>
-                <textElement textAlignment="Center"/>
+                <reportElement x="320" y="160" width="150" height="20"/>
+                <textElement textAlignment="Right">
+                    <font size="12" isBold="true"/>
+                </textElement>
                 <textFieldExpression><![CDATA[$V{totalFinal}]]></textFieldExpression>
             </textField>
         </band>


### PR DESCRIPTION
## Summary
- Ajusta el diseño de `equipos_resumen.jrxml` para alinearlo con el estilo de los reportes financieros e incorpora la columna de último movimiento
- Amplía `EquipoResumen` para exponer la fecha del último ajuste con el formato requerido por el informe
- Actualiza la consulta de resumen de equipos para recuperar las fechas de movimientos por periodo y a nivel global

## Testing
- `mvn -q -DskipTests package` *(falló: acceso 403 a Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dac6c53790832f8f0e362972b8f45e