### PR TITLE
Add Windows packaging script for bundled runtime distribution

### DIFF
--- a/docs/crear-instalador-windows.md
+++ b/docs/crear-instalador-windows.md
@@ -1,0 +1,29 @@
+# Generar instalador de Windows sin requerir Java preinstalado
+
+Este proyecto se puede distribuir como un `.exe` que incluye su propio runtime de Java. Para lograrlo se usa [jpackage](https://docs.oracle.com/en/java/javase/21/jpackage/packaging-overview.html), disponible en JDK 14 o superior.
+
+## Requisitos previos
+
+1. **JDK 21** (o superior) instalado en Windows y con `JAVA_HOME` apuntando a su carpeta. El JDK debe incluir la herramienta `jpackage` (las descargas de Oracle u OpenJDK como Temurin lo incluyen).
+2. **Maven 3.8+** disponible en la variable de entorno `PATH`.
+3. Acceso a PowerShell 5+.
+
+> ⚠️ El empaquetado `.exe` solo se puede generar desde Windows. Para otros sistemas operativos utiliza el formato nativo correspondiente (`.pkg`, `.dmg`, `.deb`, `.rpm`, etc.).
+
+## Pasos
+
+1. Abrir una consola de PowerShell en la raíz del proyecto (`control_gimnasio`).
+2. Ejecutar el script de empaquetado:
+   ```powershell
+   .\scripts\package-windows-exe.ps1 -AppVersion 1.1.0
+   ```
+   - El parámetro `-AppVersion` es opcional y permite versionar el instalador.
+   - El script ejecuta `mvn clean package` para generar un JAR con todas las dependencias y luego invoca `jpackage`.
+3. El instalador se generará dentro de la carpeta `dist/` con un nombre similar a `ControlGimnasio-1.1.0.exe`.
+4. Entrega ese archivo al cliente. El instalador incluye un runtime de Java personalizado, por lo que no se necesita instalar Java en las máquinas destino.
+
+## Contenido del instalador
+
+El instalador crea los accesos directos en el menú inicio y (opcionalmente) en el escritorio. Además, durante la instalación copia un runtime reducido de Java preparado específicamente para esta aplicación, por lo que funciona aunque el usuario no tenga Java instalado previamente.
+
+Si necesitas personalizar el nombre del acceso directo, iconos u otras opciones de jpackage, edita el script `scripts/package-windows-exe.ps1`.

--- a/pom.xml
+++ b/pom.xml
@@ -75,4 +75,34 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <finalName>control-gimnasio</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/scripts/package-windows-exe.ps1
+++ b/scripts/package-windows-exe.ps1
@@ -13,6 +13,7 @@ if (-not $JdkPath) {
 
 $projectRoot = Resolve-Path "$PSScriptRoot/.."
 $targetDir = Join-Path $projectRoot "target"
+$resourceStagingDir = Join-Path $targetDir "jpackage-resources"
 
 $mvnCmd = if (Get-Command mvn -ErrorAction SilentlyContinue) { "mvn" } else { "mvn.cmd" }
 
@@ -61,6 +62,35 @@ if ($JavaFxModulePath) {
 } else {
     Write-Host "No se especificó JavaFxModulePath; se asume que las dependencias de JavaFX están incluidas en el JAR con dependencias."
 }
+
+if (Test-Path $resourceStagingDir) {
+    Remove-Item $resourceStagingDir -Recurse -Force
+}
+
+New-Item -ItemType Directory -Force -Path $resourceStagingDir | Out-Null
+
+$resourcesToBundle = @("database", "CONFIGURACION.txt")
+
+foreach ($resource in $resourcesToBundle) {
+    $sourcePath = Join-Path $projectRoot $resource
+    if (-not (Test-Path $sourcePath)) {
+        throw "No se encontró el recurso '$resource' en el proyecto."
+    }
+
+    $destinationPath = Join-Path $resourceStagingDir $resource
+    if ((Get-Item $sourcePath).PSIsContainer) {
+        Copy-Item $sourcePath -Destination $destinationPath -Recurse -Force
+    } else {
+        $destinationParent = Split-Path $destinationPath -Parent
+        if ($destinationParent) {
+            New-Item -ItemType Directory -Force -Path $destinationParent | Out-Null
+        }
+        Copy-Item $sourcePath -Destination $destinationPath -Force
+    }
+}
+
+$jpackageArgs += @("--resource-dir", (Resolve-Path $resourceStagingDir))
+$jpackageArgs += "--win-per-user-install"
 
 Write-Host "Ejecutando jpackage para generar el instalador .exe..."
 & $jpackage @jpackageArgs

--- a/scripts/package-windows-exe.ps1
+++ b/scripts/package-windows-exe.ps1
@@ -1,7 +1,8 @@
 param(
     [string]$JdkPath = $env:JAVA_HOME,
     [string]$AppVersion = "1.1.0",
-    [string]$OutputDir = "dist"
+    [string]$OutputDir = "dist",
+    [string]$JavaFxModulePath
 )
 
 $ErrorActionPreference = "Stop"
@@ -17,6 +18,9 @@ $mvnCmd = if (Get-Command mvn -ErrorAction SilentlyContinue) { "mvn" } else { "m
 
 Write-Host "Compilando el proyecto y generando el JAR con dependencias..."
 & $mvnCmd clean package -DskipTests | Write-Output
+if ($LASTEXITCODE -ne 0) {
+    throw "La compilación con Maven finalizó con código $LASTEXITCODE. Revisa los mensajes anteriores para más detalles."
+}
 
 $mainJar = Join-Path $targetDir "control-gimnasio.jar"
 if (-not (Test-Path $mainJar)) {
@@ -32,22 +36,42 @@ New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 
 $iconPath = Join-Path $projectRoot "src/main/resources/images/icono.ico"
 
-Write-Host "Ejecutando jpackage para generar el instalador .exe..."
-& $jpackage `
-    --type exe `
-    --name "ControlGimnasio" `
-    --app-version $AppVersion `
-    --input $targetDir `
-    --main-jar (Split-Path -Leaf $mainJar) `
-    --main-class Main `
-    --dest (Resolve-Path $OutputDir) `
-    --win-shortcut `
-    --win-menu `
-    --vendor "Control Gimnasio" `
-    --icon $iconPath `
-    --add-modules "javafx.controls,javafx.fxml" `
-    --java-options "--add-opens java.base/java.lang=ALL-UNNAMED" `
-    --java-options "--add-opens java.base/java.time=ALL-UNNAMED" `
-    --jlink-options "--strip-debug --no-header-files --no-man-pages"
+$jpackageArgs = @(
+    "--type", "exe",
+    "--name", "ControlGimnasio",
+    "--app-version", $AppVersion,
+    "--input", (Resolve-Path $targetDir),
+    "--main-jar", (Split-Path -Leaf $mainJar),
+    "--main-class", "Main",
+    "--dest", (Resolve-Path $OutputDir),
+    "--win-shortcut",
+    "--win-menu",
+    "--vendor", "Control Gimnasio",
+    "--icon", (Resolve-Path $iconPath),
+    "--java-options", "--add-opens java.base/java.lang=ALL-UNNAMED",
+    "--java-options", "--add-opens java.base/java.time=ALL-UNNAMED",
+    "--jlink-options", "--strip-debug --no-header-files --no-man-pages"
+)
 
-Write-Host "Instalador generado en" (Resolve-Path $OutputDir)
+if ($JavaFxModulePath) {
+    $resolvedJavaFxPath = Resolve-Path $JavaFxModulePath -ErrorAction Stop
+    $jpackageArgs += @("--module-path", $resolvedJavaFxPath)
+    $jpackageArgs += @("--add-modules", "javafx.controls,javafx.fxml")
+    Write-Host "Usando JavaFX module path" $resolvedJavaFxPath
+} else {
+    Write-Host "No se especificó JavaFxModulePath; se asume que las dependencias de JavaFX están incluidas en el JAR con dependencias."
+}
+
+Write-Host "Ejecutando jpackage para generar el instalador .exe..."
+& $jpackage @jpackageArgs
+
+if ($LASTEXITCODE -ne 0) {
+    throw "jpackage terminó con código $LASTEXITCODE. Consulta el detalle del error impreso arriba."
+}
+
+$generatedExe = Get-ChildItem -Path $OutputDir -Filter '*.exe' -File -ErrorAction SilentlyContinue
+if (-not $generatedExe) {
+    throw "No se encontró ningún instalador .exe en '$OutputDir'. Verifica la salida de jpackage para detectar el problema."
+}
+
+Write-Host "Instalador generado en" ($generatedExe.FullName)

--- a/scripts/package-windows-exe.ps1
+++ b/scripts/package-windows-exe.ps1
@@ -1,5 +1,6 @@
 param(
     [string]$JdkPath = $env:JAVA_HOME,
+    [string]$MavenExecutable,
     [string]$AppVersion = "1.1.0",
     [string]$OutputDir = "dist",
     [string]$JavaFxModulePath
@@ -7,15 +8,106 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-if (-not $JdkPath) {
-    throw "JAVA_HOME no está configurada. Define JAVA_HOME apuntando a un JDK que incluya jpackage (JDK 14+)."
+function Resolve-JdkPath {
+    param(
+        [string]$InitialPath
+    )
+
+    $candidates = @()
+
+    if ($InitialPath) {
+        $candidates += $InitialPath
+    }
+
+    if ($env:JAVA_HOME) {
+        $candidates += $env:JAVA_HOME
+    }
+
+    if ($env:JDK_HOME) {
+        $candidates += $env:JDK_HOME
+    }
+
+    $candidates += @(
+        'C:\\java\\jdk-21',
+        'C:\\Program Files\\Java\\jdk-21',
+        'C:\\Program Files\\Java\\jdk-21.0.1',
+        'C:\\Program Files\\Eclipse Adoptium\\jdk-21',
+        'C:\\Program Files (x86)\\Java\\jdk-21'
+    )
+
+    foreach ($candidate in $candidates | Where-Object { $_ }) {
+        try {
+            $resolved = (Resolve-Path $candidate -ErrorAction Stop).Path
+            $jpackage = Join-Path $resolved "bin/jpackage.exe"
+            if (Test-Path $jpackage) {
+                return $resolved
+            }
+        } catch {
+            continue
+        }
+    }
+
+    throw "No se pudo localizar un JDK con jpackage. Define JAVA_HOME o usa el parámetro -JdkPath apuntando al directorio del JDK (por ejemplo C:\\java\\jdk-21)."
 }
+
+function Resolve-MavenExecutable {
+    param(
+        [string]$ExplicitPath
+    )
+
+    if ($ExplicitPath) {
+        try {
+            return (Resolve-Path $ExplicitPath -ErrorAction Stop).Path
+        } catch {
+            throw "No se encontró Maven en '$ExplicitPath'. Verifica la ruta especificada en -MavenExecutable."
+        }
+    }
+
+    $command = Get-Command mvn -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    $commandCmd = Get-Command mvn.cmd -ErrorAction SilentlyContinue
+    if ($commandCmd) {
+        return $commandCmd.Source
+    }
+
+    $candidates = @()
+
+    if ($env:MAVEN_HOME) {
+        $candidates += (Join-Path $env:MAVEN_HOME "bin/mvn.cmd")
+        $candidates += (Join-Path $env:MAVEN_HOME "bin/mvn")
+    }
+
+    if ($env:M2_HOME) {
+        $candidates += (Join-Path $env:M2_HOME "bin/mvn.cmd")
+        $candidates += (Join-Path $env:M2_HOME "bin/mvn")
+    }
+
+    $candidates += @(
+        'C:\\Maven\\apache-maven-3.9.11\\bin\\mvn.cmd',
+        'C:\\Program Files\\Apache\\maven\\bin\\mvn.cmd'
+    )
+
+    foreach ($candidate in $candidates | Where-Object { $_ }) {
+        if (Test-Path $candidate) {
+            return (Resolve-Path $candidate -ErrorAction Stop).Path
+        }
+    }
+
+    throw "No se pudo encontrar Maven en el PATH ni en ubicaciones comunes. Instálalo o indica la ruta con -MavenExecutable (por ejemplo C:\\Maven\\apache-maven-3.9.11\\bin\\mvn.cmd)."
+}
+
+$JdkPath = Resolve-JdkPath -InitialPath $JdkPath
+$mvnCmd = Resolve-MavenExecutable -ExplicitPath $MavenExecutable
+
+Write-Host "Usando JDK en" $JdkPath
+Write-Host "Usando Maven en" $mvnCmd
 
 $projectRoot = Resolve-Path "$PSScriptRoot/.."
 $targetDir = Join-Path $projectRoot "target"
 $resourceStagingDir = Join-Path $targetDir "jpackage-resources"
-
-$mvnCmd = if (Get-Command mvn -ErrorAction SilentlyContinue) { "mvn" } else { "mvn.cmd" }
 
 Write-Host "Compilando el proyecto y generando el JAR con dependencias..."
 & $mvnCmd clean package -DskipTests | Write-Output
@@ -54,13 +146,49 @@ $jpackageArgs = @(
     "--jlink-options", "--strip-debug --no-header-files --no-man-pages"
 )
 
+$resolvedJavaFxPath = $null
+
 if ($JavaFxModulePath) {
     $resolvedJavaFxPath = Resolve-Path $JavaFxModulePath -ErrorAction Stop
+} else {
+    $javaFxCandidates = @()
+
+    if ($env:JAVA_FX_MODULE_PATH) {
+        $javaFxCandidates += $env:JAVA_FX_MODULE_PATH
+    }
+
+    if ($env:JAVA_FX_SDK_LIB) {
+        $javaFxCandidates += $env:JAVA_FX_SDK_LIB
+    }
+
+    if ($env:JAVA_FX_SDK) {
+        $javaFxCandidates += (Join-Path $env:JAVA_FX_SDK "lib")
+    }
+
+    $javaFxCandidates += @(
+        'C:\\java\\javafx-sdk-21\\lib',
+        'C:\\javafx-sdk-21\\lib'
+    )
+
+    foreach ($candidate in $javaFxCandidates) {
+        if (-not $candidate) { continue }
+        if (Test-Path $candidate) {
+            try {
+                $resolvedJavaFxPath = Resolve-Path $candidate -ErrorAction Stop
+                break
+            } catch {
+                continue
+            }
+        }
+    }
+}
+
+if ($resolvedJavaFxPath) {
     $jpackageArgs += @("--module-path", $resolvedJavaFxPath)
     $jpackageArgs += @("--add-modules", "javafx.controls,javafx.fxml")
     Write-Host "Usando JavaFX module path" $resolvedJavaFxPath
 } else {
-    Write-Host "No se especificó JavaFxModulePath; se asume que las dependencias de JavaFX están incluidas en el JAR con dependencias."
+    Write-Host "No se especificó JavaFxModulePath ni se detectó automáticamente; se asume que las dependencias de JavaFX están incluidas en el JAR con dependencias."
 }
 
 if (Test-Path $resourceStagingDir) {

--- a/scripts/package-windows-exe.ps1
+++ b/scripts/package-windows-exe.ps1
@@ -1,0 +1,53 @@
+param(
+    [string]$JdkPath = $env:JAVA_HOME,
+    [string]$AppVersion = "1.1.0",
+    [string]$OutputDir = "dist"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $JdkPath) {
+    throw "JAVA_HOME no está configurada. Define JAVA_HOME apuntando a un JDK que incluya jpackage (JDK 14+)."
+}
+
+$projectRoot = Resolve-Path "$PSScriptRoot/.."
+$targetDir = Join-Path $projectRoot "target"
+
+$mvnCmd = if (Get-Command mvn -ErrorAction SilentlyContinue) { "mvn" } else { "mvn.cmd" }
+
+Write-Host "Compilando el proyecto y generando el JAR con dependencias..."
+& $mvnCmd clean package -DskipTests | Write-Output
+
+$mainJar = Join-Path $targetDir "control-gimnasio.jar"
+if (-not (Test-Path $mainJar)) {
+    throw "No se encontró $mainJar. Verifica que la fase de empaquetado se ejecutó correctamente."
+}
+
+$jpackage = Join-Path $JdkPath "bin/jpackage.exe"
+if (-not (Test-Path $jpackage)) {
+    throw "No se encontró jpackage en $jpackage. Asegúrate de usar un JDK completo (no solo un JRE)."
+}
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+$iconPath = Join-Path $projectRoot "src/main/resources/images/icono.ico"
+
+Write-Host "Ejecutando jpackage para generar el instalador .exe..."
+& $jpackage `
+    --type exe `
+    --name "ControlGimnasio" `
+    --app-version $AppVersion `
+    --input $targetDir `
+    --main-jar (Split-Path -Leaf $mainJar) `
+    --main-class Main `
+    --dest (Resolve-Path $OutputDir) `
+    --win-shortcut `
+    --win-menu `
+    --vendor "Control Gimnasio" `
+    --icon $iconPath `
+    --add-modules "javafx.controls,javafx.fxml" `
+    --java-options "--add-opens java.base/java.lang=ALL-UNNAMED" `
+    --java-options "--add-opens java.base/java.time=ALL-UNNAMED" `
+    --jlink-options "--strip-debug --no-header-files --no-man-pages"
+
+Write-Host "Instalador generado en" (Resolve-Path $OutputDir)

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -5,6 +5,8 @@ import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
+import util.AppPaths;
+
 public class Main extends Application {
 
     @Override
@@ -18,6 +20,7 @@ public class Main extends Application {
     }
 
     public static void main(String[] args) {
+        AppPaths.initialize();
         launch(args);
     }
 }

--- a/src/main/java/controllers/AdminDashboardController.java
+++ b/src/main/java/controllers/AdminDashboardController.java
@@ -11,6 +11,7 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
 import models.Role;
+import util.AppPaths;
 import util.BackupUtil;
 import util.DashboardService;
 import util.SessionManager;
@@ -235,7 +236,7 @@ public class AdminDashboardController implements Initializable {
     @FXML
     private void abrirRespaldos() {
         try {
-            Path dir = Path.of("backups");
+            Path dir = AppPaths.getBackupsDir();
             if (!Files.exists(dir)) {
                 lblMensaje.setText("No hay respaldos disponibles");
                 return;

--- a/src/main/java/util/AlertScheduler.java
+++ b/src/main/java/util/AlertScheduler.java
@@ -15,7 +15,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.text.ParseException;
 import org.quartz.CronExpression;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.io.IOException;
 
 public class AlertScheduler implements Runnable {
@@ -44,7 +45,7 @@ public class AlertScheduler implements Runnable {
      * Lee la configuración de frecuencia de respaldo desde CONFIGURACION.txt.
      */
     private static String obtenerFrecuenciaRespaldo() {
-        Path config = Paths.get("CONFIGURACION.txt");
+        Path config = AppPaths.getConfigFile();
         if (Files.exists(config)) {
             try {
                 return Files.lines(config)

--- a/src/main/java/util/AppPaths.java
+++ b/src/main/java/util/AppPaths.java
@@ -1,0 +1,145 @@
+package util;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * Gestiona las rutas de archivos utilizados por la aplicación tanto en modo desarrollo
+ * como cuando se ejecuta desde un instalador generado con jpackage.
+ */
+public final class AppPaths {
+    private static final Path DATA_DIR = computeDataDir();
+    private static final Path DATABASE_PATH = DATA_DIR.resolve(Paths.get("database", "gimnasio.db"));
+    private static final Path BACKUP_DIR = DATA_DIR.resolve("backups");
+    private static final Path CONFIG_FILE = DATA_DIR.resolve("CONFIGURACION.txt");
+    private static final Path BUNDLED_RESOURCE_ROOT = locateBundledResources();
+
+    private static volatile boolean initialized = false;
+
+    private AppPaths() {
+    }
+
+    /**
+     * Asegura que los directorios de datos existen y que los recursos iniciales
+     * (base de datos y archivo de configuración) están disponibles en una
+     * ubicación escribible para el usuario actual.
+     */
+    public static synchronized void initialize() {
+        if (initialized) {
+            return;
+        }
+        try {
+            Files.createDirectories(DATABASE_PATH.getParent());
+            Files.createDirectories(BACKUP_DIR);
+            copyIfMissing(BUNDLED_RESOURCE_ROOT.resolve(Paths.get("database", "gimnasio.db")), DATABASE_PATH);
+            copyIfMissing(BUNDLED_RESOURCE_ROOT.resolve("CONFIGURACION.txt"), CONFIG_FILE);
+            initialized = true;
+        } catch (IOException e) {
+            throw new IllegalStateException("No se pudieron preparar los archivos necesarios: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Devuelve la ruta al directorio de datos escribible.
+     */
+    public static Path getDataDir() {
+        ensureInitialized();
+        return DATA_DIR;
+    }
+
+    /**
+     * Devuelve la ruta absoluta a la base de datos SQLite en uso.
+     */
+    public static Path getDatabasePath() {
+        ensureInitialized();
+        return DATABASE_PATH;
+    }
+
+    /**
+     * Devuelve la ruta al directorio de respaldos.
+     */
+    public static Path getBackupsDir() {
+        ensureInitialized();
+        return BACKUP_DIR;
+    }
+
+    /**
+     * Devuelve la ruta al archivo de configuración del sistema.
+     */
+    public static Path getConfigFile() {
+        ensureInitialized();
+        return CONFIG_FILE;
+    }
+
+    private static void ensureInitialized() {
+        if (!initialized) {
+            initialize();
+        }
+    }
+
+    private static Path computeDataDir() {
+        String os = System.getProperty("os.name", "").toLowerCase();
+        if (os.contains("win")) {
+            String localAppData = System.getenv("LOCALAPPDATA");
+            if (localAppData != null && !localAppData.isBlank()) {
+                return Paths.get(localAppData, "ControlGimnasio");
+            }
+        }
+        return Paths.get(System.getProperty("user.home"), ".control_gimnasio");
+    }
+
+    private static void copyIfMissing(Path source, Path target) throws IOException {
+        if (Files.exists(target)) {
+            return;
+        }
+        if (!Files.exists(source)) {
+            throw new IOException("No se encontró el recurso empaquetado: " + source);
+        }
+        Path parent = target.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        Files.copy(source, target, StandardCopyOption.COPY_ATTRIBUTES);
+    }
+
+    private static Path locateBundledResources() {
+        Path base = resolveCodeSourceBase();
+        Path located = findResourceRoot(base);
+        if (located != null) {
+            return located;
+        }
+        Path workingDir = Paths.get("").toAbsolutePath();
+        located = findResourceRoot(workingDir);
+        if (located != null) {
+            return located;
+        }
+        throw new IllegalStateException("No se encontró la carpeta 'database' ni el archivo CONFIGURACION.txt en el instalador.");
+    }
+
+    private static Path resolveCodeSourceBase() {
+        try {
+            Path codeSource = Paths.get(AppPaths.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+            if (Files.isRegularFile(codeSource)) {
+                return codeSource.getParent();
+            }
+            return codeSource;
+        } catch (URISyntaxException e) {
+            return Paths.get("").toAbsolutePath();
+        }
+    }
+
+    private static Path findResourceRoot(Path start) {
+        Path current = start;
+        for (int i = 0; i < 6 && current != null; i++) {
+            if (Files.isDirectory(current.resolve("database")) && Files.exists(current.resolve("CONFIGURACION.txt"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        return null;
+    }
+}

--- a/src/main/java/util/BackupUtil.java
+++ b/src/main/java/util/BackupUtil.java
@@ -1,7 +1,9 @@
 package util;
 
 import java.io.IOException;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -10,8 +12,8 @@ import java.time.format.DateTimeFormatter;
  * Utilidad para crear respaldos de la base de datos.
  */
 public class BackupUtil implements Runnable {
-    private static final Path DB_PATH = Paths.get("database", "gimnasio.db");
-    private static final Path BACKUP_DIR = Paths.get("backups");
+    private static final Path DB_PATH = AppPaths.getDatabasePath();
+    private static final Path BACKUP_DIR = AppPaths.getBackupsDir();;
 
     @Override
     public void run() {

--- a/src/main/java/util/DatabaseUtil.java
+++ b/src/main/java/util/DatabaseUtil.java
@@ -32,7 +32,7 @@ import models.IngresoData;
 import models.EquipoResumen;
 
 public class DatabaseUtil {
-    private static final String URL = "jdbc:sqlite:database/gimnasio.db";
+    private static final String URL = "jdbc:sqlite:" + AppPaths.getDatabasePath().toAbsolutePath();
     private static final int BUSY_TIMEOUT_MS = 60000;
     private static final DateTimeFormatter SQLITE_DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final Pattern PAGO_ID_PATTERN = Pattern.compile("Pago\\s+(\\d+)", Pattern.CASE_INSENSITIVE);


### PR DESCRIPTION
## Summary
- configure the Maven assembly plugin to generate a runnable fat JAR for packaging
- add a PowerShell helper that calls jpackage to build a Windows installer including a custom runtime
- document the steps to produce the installer without requiring Java on the target machines

## Testing
- `mvn -q -DskipTests package` *(fails: status code 403 downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e76471bc832fb87328b14875aa7f