### PR TITLE
Handle missing SQLite directory during startup

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,126 @@
+# Guía completa para generar un instalador `.exe` sin errores de JVM
+
+Este repositorio contiene una aplicación JavaFX empaquetada con Maven. Para distribuirla como ejecutable en Windows necesitas:
+
+1. Un **JDK 21** configurado correctamente.
+2. Las librerías JavaFX en formato **jmods** (requeridas por `jpackage`).
+3. Un `.jar` con todas las dependencias de tu aplicación.
+4. Un comando o script que invoque `jpackage` y agrupe todo en un instalador.
+
+Los apartados siguientes detallan cada paso y te proporcionan un script reutilizable junto con una configuración opcional para Launch4j.
+
+## 1. Preparar el entorno de construcción
+
+1. Instala **JDK 21** (por ejemplo en `C:\java\jdk-21`) y define las variables de entorno en *Panel de control → Sistema → Configuración avanzada del sistema → Variables de entorno*:
+   - `JAVA_HOME=C:\java\jdk-21`
+   - Añade `%JAVA_HOME%\bin` al **inicio** de `PATH`.
+2. Descarga el paquete **JavaFX jmods** que coincida con tu versión (por ejemplo `javafx-jmods-21.zip`) desde [https://gluonhq.com/products/javafx/](https://gluonhq.com/products/javafx/) y descomprímelo, por ejemplo en `C:\java\javafx-jmods-21`.
+3. Crea la variable `JAVAFX_JMODS=C:\java\javafx-jmods-21` y comprueba todo desde una ventana de *Command Prompt*:
+
+   ```bat
+   echo %JAVA_HOME%
+   dir %JAVA_HOME%\bin
+   where java
+   where jpackage
+   echo %JAVAFX_JMODS%
+   dir %JAVAFX_JMODS%
+   ```
+
+   Las rutas deben apuntar a los directorios que acabas de configurar. Si `where java` muestra otras instalaciones (por ejemplo `javapath`), deja tu JDK 21 al inicio del `PATH` para que tenga prioridad.
+
+4. Verifica que Maven esté disponible (`mvn -v`). Si no lo tienes, instala [Apache Maven](https://maven.apache.org/download.cgi) y añade su carpeta `bin` al `PATH`.
+
+## 2. Generar el `.jar` con dependencias
+
+El proyecto ya define la clase principal `Main` en `src/main/java/Main.java`. Para producir un `jar` listo para empaquetar ejecuta en la raíz del repositorio:
+
+```bat
+mvn clean package
+mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target\installer\app\lib
+```
+
+Los comandos anteriores generan:
+
+* `target/gimnasio_control-1.0-SNAPSHOT.jar`: el artefacto principal.
+* `target/installer/app/lib`: todas las dependencias externas (JavaFX, JasperReports, Selenium, etc.) listas para que `jpackage` las incluya en el classpath.
+
+## 3. Script automatizado con `jpackage`
+
+Para evitar errores al lanzar la JVM se incluye el script `installer/windows/build-installer.ps1`. Ejecuta una terminal de **PowerShell** y lanza:
+
+```powershell
+cd RUTA\AL\PROYECTO
+powershell -ExecutionPolicy Bypass -File installer/windows/build-installer.ps1 \
+  -AppVersion "1.0.0" \
+  -Vendor "Tu Empresa" \
+  -UpgradeUuid "12345678-1234-1234-1234-123456789abc"
+```
+
+El script realiza automáticamente:
+
+1. Validaciones de entorno (`JAVA_HOME`, `JAVAFX_JMODS`, Maven y `jpackage`).
+2. Construcción del `jar` y copiado de dependencias, archivos de configuración (`CONFIGURACION.txt`), carpeta `lib/`, recursos gráficos y respaldos necesarios.
+3. Ejecución de `jpackage` con `Main` como clase principal, icono `src/main/resources/images/icono.ico`, módulos JavaFX y opciones para crear accesos directos del menú de inicio.
+4. Generación de un instalador en `target/installer/GimnasioControl-1.0.0.exe` (puedes ajustar el nombre con los parámetros del script).
+
+Revisa `installer/windows/README.md` para conocer todos los parámetros personalizables del script.
+
+### Resultado del directorio `target/installer`
+
+```
+target/installer/
+├─ app/                (archivos que usará jpackage)
+│  ├─ GimnasioControl.jar
+│  ├─ CONFIGURACION.txt (si existe en el proyecto)
+│  ├─ lib/             (dependencias externas)
+│  ├─ images/          (recursos estáticos)
+│  └─ backups/         (copias de seguridad, si las tuvieras)
+└─ GimnasioControl-1.0.0.exe
+```
+
+Prueba el `.exe` final en una máquina Windows limpia para confirmar que la JVM embebida funciona correctamente.
+
+## 4. Personalizar o depurar `jpackage`
+
+Si necesitas ejecutar `jpackage` manualmente (por ejemplo para depurar), puedes basarte en el comando que genera el script:
+
+```bat
+jpackage ^
+  --type exe ^
+  --name GimnasioControl ^
+  --input target\installer\app ^
+  --main-jar GimnasioControl.jar ^
+  --main-class Main ^
+  --class-path lib\* ^
+  --module-path %JAVAFX_JMODS%;%JAVA_HOME%\jmods ^
+  --add-modules javafx.controls,javafx.fxml ^
+  --java-options "-Dfile.encoding=UTF-8" ^
+  --icon src\main\resources\images\icono.ico ^
+  --dest target\installer ^
+  --win-shortcut ^
+  --win-menu ^
+  --win-dir-chooser ^
+  --win-menu-group "Tu Empresa" ^
+  --win-upgrade-uuid 12345678-1234-1234-1234-123456789abc
+```
+
+Sustituye parámetros como `--name`, `--win-menu-group`, `--win-upgrade-uuid` o el icono según tus necesidades.
+
+## 5. Alternativa: Launch4j con JVM embebida
+
+Si prefieres un ejecutable ligero que delegue en un JRE empacado manualmente, utiliza [Launch4j](https://launch4j.sourceforge.net/). Este repositorio incluye la plantilla `installer/windows/launch4j-config.xml` que espera la siguiente estructura:
+
+```
+dist/
+├─ GimnasioControl.exe         (resultado de Launch4j)
+├─ GimnasioControl.jar         (renombrado desde target/gimnasio_control-1.0-SNAPSHOT.jar)
+├─ lib/                        (dependencias externas)
+├─ jre/                        (JRE o JDK recortado con jlink)
+└─ recursos adicionales
+```
+
+Abre el archivo XML en la interfaz de Launch4j para ajustar datos como el `outfile`, la ruta del icono o el identificador de tu empresa. Después puedes empaquetar la carpeta `dist/` con instaladores como Inno Setup o NSIS.
+
+---
+
+Con estas herramientas y archivos dispones de todo lo necesario para generar un `.exe` estable y listo para distribución sin errores de tipo “Failed to launch JVM”.

--- a/installer/windows/README.md
+++ b/installer/windows/README.md
@@ -1,0 +1,63 @@
+# Construir el instalador de Windows
+
+El script `build-installer.ps1` automatiza los pasos para generar un `.exe` de Gimnasio Control con `jpackage`. Debe ejecutarse desde PowerShell (Windows 10/11) con permisos para escribir en el directorio `target/installer`.
+
+## Requisitos previos
+
+1. `JAVA_HOME` apuntando a un **JDK 21** que contenga `bin\jpackage.exe`.
+2. `PATH` iniciado con `%JAVA_HOME%\bin` para que Windows utilice el JDK correcto.
+3. `JAVAFX_JMODS` apuntando al directorio que contiene los archivos `*.jmod` de JavaFX (por ejemplo `C:\java\javafx-jmods-21`).
+4. [Apache Maven](https://maven.apache.org/) instalado y disponible en el `PATH`.
+5. PowerShell 5.1 o superior.
+
+Puedes verificar rápidamente que el entorno está listo con:
+
+```powershell
+Get-Command mvn
+Get-Command "$env:JAVA_HOME\bin\jpackage.exe"
+Test-Path $env:JAVAFX_JMODS
+```
+
+Si alguno de los comandos devuelve `False` o un error, corrige las variables de entorno antes de continuar.
+
+## Uso básico
+
+```powershell
+powershell -ExecutionPolicy Bypass -File installer/windows/build-installer.ps1
+```
+
+Al ejecutarlo sin parámetros el script utiliza valores por defecto:
+
+| Parámetro       | Valor por defecto             | Descripción |
+|-----------------|-------------------------------|-------------|
+| `AppName`       | `GimnasioControl`              | Nombre de la aplicación e instalador. |
+| `AppVersion`    | `1.0.0`                        | Se usa para el nombre del archivo `.exe` y metadatos. |
+| `Vendor`        | `Gimnasio Control`             | Fabricante mostrado en el instalador y menú inicio. |
+| `MainClass`     | `Main`                         | Clase principal del proyecto. |
+| `IconPath`      | `src\main\resources\images\icono.ico` | Icono que verá el usuario. |
+| `UpgradeUuid`   | Generado automáticamente       | Identificador para actualizaciones de Windows. |
+
+### Personalización
+
+Ejemplo con valores propios:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File installer/windows/build-installer.ps1 \
+  -AppName "ControlGimnasio" \
+  -AppVersion "1.2.3" \
+  -Vendor "Mi Empresa" \
+  -IconPath "assets\branding\logo.ico" \
+  -UpgradeUuid "0e0465fd-9cbf-4baf-8f62-4f2d4a0b7d63"
+```
+
+## Qué genera el script
+
+* `target/installer/app/` con el `.jar`, dependencias y recursos necesarios.
+* `target/installer/GimnasioControl-1.0.0.exe` (o el nombre según tus parámetros).
+* Un archivo de log de jpackage en la consola para depuración.
+
+Repite la ejecución cada vez que haya cambios en el código o dependencias.
+
+## Launch4j como alternativa
+
+Si prefieres crear un ejecutable ligero con una JVM empaquetada manualmente, abre el archivo `launch4j-config.xml` con Launch4j, ajusta rutas e iconos y genera el `.exe`. Posteriormente, empaca el directorio resultante con Inno Setup, NSIS u otra herramienta de instaladores.

--- a/installer/windows/build-installer.ps1
+++ b/installer/windows/build-installer.ps1
@@ -1,0 +1,107 @@
+[CmdletBinding()]
+param(
+    [string]$AppName = "GimnasioControl",
+    [string]$AppVersion = "1.0.0",
+    [string]$Vendor = "Gimnasio Control",
+    [string]$MainClass = "Main",
+    [string]$IconPath = "src\main\resources\images\icono.ico",
+    [string]$UpgradeUuid = "",
+    [string]$JavaFxJmods = $env:JAVAFX_JMODS
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-FileExists {
+    param([string]$Path, [string]$Message)
+    if (-not (Test-Path $Path)) {
+        throw $Message
+    }
+}
+
+function Invoke-CommandChecked {
+    param([string]$Command, [string[]]$Arguments)
+    Write-Host "→ $Command $($Arguments -join ' ')"
+    $process = Start-Process -FilePath $Command -ArgumentList $Arguments -NoNewWindow -PassThru -Wait
+    if ($process.ExitCode -ne 0) {
+        throw "El comando '$Command' terminó con código $($process.ExitCode)."
+    }
+}
+
+$projectRoot = Resolve-Path "$PSScriptRoot\..\.."
+Set-Location $projectRoot
+
+Assert-FileExists -Path $env:JAVA_HOME -Message "JAVA_HOME no está definido o apunta a una ruta inexistente."
+Assert-FileExists -Path (Join-Path $env:JAVA_HOME 'bin\jpackage.exe') -Message "No se encontró jpackage en %JAVA_HOME%\bin. Instala un JDK 21 completo."
+
+if (-not $JavaFxJmods) {
+    throw "Debes definir la variable de entorno JAVAFX_JMODS apuntando a los jmods de JavaFX (por ejemplo C:\\java\\javafx-jmods-21)."
+}
+Assert-FileExists -Path $JavaFxJmods -Message "La ruta definida en JAVAFX_JMODS no existe: $JavaFxJmods"
+
+if (-not (Get-Command mvn -ErrorAction SilentlyContinue)) {
+    throw "No se encontró Maven en el PATH. Instala Maven y agrégalo al PATH."
+}
+
+$installerRoot = Join-Path $projectRoot 'target\installer'
+$appDir = Join-Path $installerRoot 'app'
+$libDir = Join-Path $appDir 'lib'
+
+if (Test-Path $appDir) {
+    Remove-Item $appDir -Recurse -Force
+}
+New-Item -ItemType Directory -Path $libDir -Force | Out-Null
+
+Invoke-CommandChecked -Command 'mvn' -Arguments @('clean', 'package', '--batch-mode')
+Invoke-CommandChecked -Command 'mvn' -Arguments @('dependency:copy-dependencies', '-DincludeScope=runtime', "-DoutputDirectory=$libDir", '--batch-mode')
+
+$artifact = Join-Path $projectRoot 'target\gimnasio_control-1.0-SNAPSHOT.jar'
+Assert-FileExists -Path $artifact -Message "No se generó el jar esperado en target/. Verifica que Maven haya terminado correctamente."
+
+$mainJar = Join-Path $appDir ("{0}.jar" -f $AppName)
+Copy-Item $artifact $mainJar -Force
+
+$extraItems = @('CONFIGURACION.txt', 'lib', 'backups')
+foreach ($item in $extraItems) {
+    $source = Join-Path $projectRoot $item
+    if (Test-Path $source) {
+        Copy-Item $source $appDir -Recurse -Force
+    }
+}
+
+$imagesDir = Join-Path $projectRoot 'src\main\resources\images'
+if (Test-Path $imagesDir) {
+    Copy-Item $imagesDir (Join-Path $appDir 'images') -Recurse -Force
+}
+
+$resolvedIcon = Resolve-Path (Join-Path $projectRoot $IconPath)
+$uuid = if ([string]::IsNullOrWhiteSpace($UpgradeUuid)) { ([guid]::NewGuid()).ToString() } else { $UpgradeUuid }
+
+$modulePath = (Join-Path $env:JAVA_HOME 'jmods') + ';' + (Resolve-Path $JavaFxJmods)
+$jpackage = Join-Path $env:JAVA_HOME 'bin\jpackage.exe'
+
+$jpackageArgs = @(
+    '--type', 'exe',
+    '--name', $AppName,
+    '--app-version', $AppVersion,
+    '--vendor', $Vendor,
+    '--input', $appDir,
+    '--main-jar', (Split-Path $mainJar -Leaf),
+    '--main-class', $MainClass,
+    '--class-path', 'lib\\*',
+    '--module-path', $modulePath,
+    '--add-modules', 'javafx.controls,javafx.fxml',
+    '--java-options', '-Dfile.encoding=UTF-8',
+    '--icon', $resolvedIcon,
+    '--dest', $installerRoot,
+    '--win-dir-chooser',
+    '--win-shortcut',
+    '--win-menu',
+    '--win-menu-group', $Vendor,
+    '--win-upgrade-uuid', $uuid
+)
+
+Write-Host "Ejecutando jpackage..."
+Invoke-CommandChecked -Command $jpackage -Arguments $jpackageArgs
+
+Write-Host "Instalador generado en:" (Join-Path $installerRoot ("{0}-{1}.exe" -f $AppName, $AppVersion))
+Write-Host "UUID de actualización utilizado: $uuid"

--- a/installer/windows/launch4j-config.xml
+++ b/installer/windows/launch4j-config.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch4jConfig>
+  <dontWrapJar>false</dontWrapJar>
+  <headerType>gui</headerType>
+  <jar>..\..\target\installer\app\GimnasioControl.jar</jar>
+  <outfile>..\..\target\installer\GimnasioControl.exe</outfile>
+  <errTitle>Gimnasio Control</errTitle>
+  <cmdLine></cmdLine>
+  <chdir>.</chdir>
+  <priority>normal</priority>
+  <downloadUrl>https://adoptium.net/</downloadUrl>
+  <supportUrl></supportUrl>
+  <stayAlive>false</stayAlive>
+  <restartOnCrash>false</restartOnCrash>
+  <manifest></manifest>
+  <icon>..\..\src\main\resources\images\icono.ico</icon>
+  <classPath>
+    <mainClass>Main</mainClass>
+    <cp>lib\*</cp>
+  </classPath>
+  <jre>
+    <path>jre</path>
+    <bundledJre64Bit>true</bundledJre64Bit>
+    <minVersion>21</minVersion>
+    <jdkPreference>preferJre</jdkPreference>
+    <runtimeBits>64/32</runtimeBits>
+  </jre>
+  <splash>
+    <file>..\..\src\main\resources\images\icono.ico</file>
+    <waitForWindow>true</waitForWindow>
+    <timeout>60</timeout>
+    <timeoutErr>true</timeoutErr>
+  </splash>
+</launch4jConfig>

--- a/src/main/java/util/BackupUtil.java
+++ b/src/main/java/util/BackupUtil.java
@@ -36,6 +36,10 @@ public class BackupUtil implements Runnable {
             if (!Files.exists(dir)) {
                 Files.createDirectories(dir);
             }
+            if (!Files.exists(DB_PATH)) {
+                System.out.println("No se encontró la base de datos en " + DB_PATH + ". Se omite respaldo " + tipo + ".");
+                return;
+            }
             LocalDateTime ahora = LocalDateTime.now();
             String nombreArchivo;
             if ("diario".equalsIgnoreCase(tipo)) {

--- a/src/main/java/util/DatabaseUtil.java
+++ b/src/main/java/util/DatabaseUtil.java
@@ -1,5 +1,8 @@
 package util;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -32,12 +35,14 @@ import models.IngresoData;
 import models.EquipoResumen;
 
 public class DatabaseUtil {
+    private static final Path DB_DIRECTORY = Paths.get("database");
     private static final String URL = "jdbc:sqlite:database/gimnasio.db";
     private static final int BUSY_TIMEOUT_MS = 60000;
     private static final DateTimeFormatter SQLITE_DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final Pattern PAGO_ID_PATTERN = Pattern.compile("Pago\\s+(\\d+)", Pattern.CASE_INSENSITIVE);
 
     public static Connection getConnection() throws SQLException {
+        ensureDatabaseDirectory();
         Connection conn = DriverManager.getConnection(URL);
         try (Statement stmt = conn.createStatement()) {
             stmt.execute("PRAGMA journal_mode = WAL");
@@ -46,6 +51,17 @@ public class DatabaseUtil {
             stmt.execute("PRAGMA foreign_keys = ON");
         }
         return conn;
+    }
+
+    private static void ensureDatabaseDirectory() throws SQLException {
+        if (Files.exists(DB_DIRECTORY)) {
+            return;
+        }
+        try {
+            Files.createDirectories(DB_DIRECTORY);
+        } catch (Exception e) {
+            throw new SQLException("No se pudo crear el directorio de la base de datos", e);
+        }
     }
 
     public static synchronized void initDatabase() {


### PR DESCRIPTION
## Summary
- ensure `DatabaseUtil` creates the `database` directory before opening SQLite connections so the splash screen can advance reliably
- skip backup attempts when the database file has not been created yet to avoid noisy errors during the first launch

## Testing
- mvn -q -DskipTests package *(fails: Maven central returned 403 while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68e54f44ae6c832fae3c64b5798a1b48