### PR TITLE
Keep bundled database in installation directory

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,162 @@
+# Guía completa para generar un instalador `.exe` sin errores de JVM
+
+Este repositorio contiene una aplicación JavaFX empaquetada con Maven. Para distribuirla como ejecutable en Windows necesitas:
+
+1. Un **JDK 21** configurado correctamente.
+2. Las librerías JavaFX en formato **jmods** (requeridas por `jpackage`).
+3. Un `.jar` con todas las dependencias de tu aplicación.
+4. Un comando o script que invoque `jpackage` y agrupe todo en un instalador.
+
+Los apartados siguientes detallan cada paso y te proporcionan un script reutilizable junto con una configuración opcional para Launch4j.
+
+## 1. Preparar el entorno de construcción
+
+1. Instala **JDK 21** (por ejemplo en `C:\java\jdk-21`) y define las variables de entorno en *Panel de control → Sistema → Configuración avanzada del sistema → Variables de entorno*:
+   - `JAVA_HOME=C:\java\jdk-21`
+   - Añade `%JAVA_HOME%\bin` al **inicio** de `PATH`.
+2. Descarga el paquete **JavaFX jmods** que coincida con tu versión (por ejemplo `javafx-jmods-21.zip`) desde [https://gluonhq.com/products/javafx/](https://gluonhq.com/products/javafx/) y descomprímelo, por ejemplo en `C:\java\javafx-jmods-21`.
+3. Crea la variable `JAVAFX_JMODS=C:\java\javafx-jmods-21` y comprueba todo desde una ventana de *Command Prompt*:
+
+   ```bat
+   echo %JAVA_HOME%
+   dir %JAVA_HOME%\bin
+   where java
+   where jpackage
+   echo %JAVAFX_JMODS%
+   dir %JAVAFX_JMODS%
+   ```
+
+   Las rutas deben apuntar a los directorios que acabas de configurar. Si `where java` muestra otras instalaciones (por ejemplo `javapath`), deja tu JDK 21 al inicio del `PATH` para que tenga prioridad.
+
+4. Verifica que Maven esté disponible (`mvn -v`). Si no lo tienes, instala [Apache Maven](https://maven.apache.org/download.cgi) y añade su carpeta `bin` al `PATH`.
+
+## 2. Generar el `.jar` con dependencias
+
+El proyecto ya define la clase principal `Main` en `src/main/java/Main.java`. Para producir un `jar` listo para empaquetar ejecuta en la raíz del repositorio:
+
+```bat
+mvn clean package
+mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target\installer\app\lib
+```
+
+Los comandos anteriores generan:
+
+* `target/gimnasio_control-1.0-SNAPSHOT.jar`: el artefacto principal.
+* `target/installer/app/lib`: todas las dependencias externas (JavaFX, JasperReports, Selenium, etc.) listas para que `jpackage` las incluya en el classpath.
+
+### ¿Cómo compruebo que la carpeta `lib` está completa?
+
+Al finalizar los comandos anteriores deberías ver la carpeta `target/installer/app/lib` repleta de `.jar`. Es normal encontrar decenas de archivos, porque Maven copia tanto las dependencias directas como las transitivas. Para confirmar que no falta nada crítico revisa que estén, al menos, estos grupos:
+
+* **JavaFX (con sufijo `-win`)**: `javafx-base-21-win.jar`, `javafx-graphics-21-win.jar`, `javafx-controls-21-win.jar` y `javafx-fxml-21-win.jar`. Si faltan los `-win` es señal de que no se descargaron los artefactos nativos y la interfaz no podrá arrancar.
+* **Base de datos y reportes**: `sqlite-jdbc-3.42.0.0.jar` y `jasperreports-6.20.0.jar` (más sus complementos `commons-logging`, `itext`, etc.). Sin ellos, la inicialización de la base o los reportes bloquearán el *splash*.
+* **Programador y automatización**: `quartz-2.3.2.jar`, `selenium-java-4.32.0.jar` y `selenium-devtools-v138-4.34.0.jar`, acompañados de los `client-combined`, `okhttp`, `gson`, `byte-buddy`, etc., que suelen aparecer juntos.
+* **Iconografía**: `ikonli-javafx-12.3.1.jar` y `ikonli-fontawesome5-pack-12.3.1.jar`.
+
+Si cualquiera de esos grupos falta, vuelve a ejecutar `mvn dependency:copy-dependencies ...` y verifica que no haya fallado por problemas de red. Cuando todo está presente, el instalador contará con el *classpath* completo y el arranque pasará del *splash* al login sin errores de clases faltantes.
+
+## 3. Script automatizado con `jpackage`
+
+Para evitar errores al lanzar la JVM se incluye el script `installer/windows/build-installer.ps1`. Ejecuta una terminal de **PowerShell** y lanza:
+
+```powershell
+cd RUTA\AL\PROYECTO
+powershell -ExecutionPolicy Bypass -File installer/windows/build-installer.ps1 \
+  -AppVersion "1.0.0" \
+  -Vendor "Tu Empresa" \
+  -UpgradeUuid "12345678-1234-1234-1234-123456789abc"
+```
+
+El script realiza automáticamente:
+
+1. Validaciones de entorno (`JAVA_HOME`, `JAVAFX_JMODS`, Maven y `jpackage`).
+2. Construcción del `jar` y copiado de dependencias, archivos de configuración (`CONFIGURACION.txt`), carpeta `lib/`, recursos gráficos y respaldos necesarios.
+3. Ejecución de `jpackage` con `Main` como clase principal, icono `src/main/resources/images/icono.ico`, y los módulos requeridos (`javafx.controls`, `javafx.fxml`, `javafx.graphics`, `java.sql`, `java.xml`, `java.naming`, `java.desktop`, `java.management`, `java.scripting`) para que el runtime embebido incluya todo lo que usan JasperReports, Quartz, Selenium y la capa de base de datos.
+4. Generación de un instalador en `target/installer/GimnasioControl-1.0.0.exe` (puedes ajustar el nombre con los parámetros del script).
+
+Revisa `installer/windows/README.md` para conocer todos los parámetros personalizables del script.
+
+### Resultado del directorio `target/installer`
+
+```
+target/installer/
+├─ app/                (archivos que usará jpackage)
+│  ├─ GimnasioControl.jar
+│  ├─ CONFIGURACION.txt (si existe en el proyecto)
+│  ├─ lib/             (dependencias externas)
+│  ├─ images/          (recursos estáticos)
+│  └─ backups/         (copias de seguridad, si las tuvieras)
+└─ GimnasioControl-1.0.0.exe
+```
+
+> **Importante:** la base de datos real (`gimnasio.db`) **no** se incluye dentro de `app/lib`. Esa carpeta solo contiene
+> bibliotecas `.jar`. El archivo de datos se crea dinámicamente dentro de la carpeta `database/` que acompaña al ejecutable
+> (es decir, en `database\gimnasio.db` relativo al directorio de instalación) o, si defines la variable de entorno
+> `CONTROL_GIMNASIO_HOME`, en la ruta personalizada indicada. Por lo tanto, al instalar el sistema no necesitas copiar una base
+> ya existente dentro del paquete. Solo asegúrate de que la aplicación tenga permisos para crearla en la primera ejecución.
+
+Prueba el `.exe` final en una máquina Windows limpia para confirmar que la JVM embebida funciona correctamente.
+
+## 4. Personalizar o depurar `jpackage`
+
+Si necesitas ejecutar `jpackage` manualmente (por ejemplo para depurar), puedes basarte en el comando que genera el script:
+
+```bat
+jpackage ^
+  --type exe ^
+  --name GimnasioControl ^
+  --input target\installer\app ^
+  --main-jar GimnasioControl.jar ^
+  --main-class Main ^
+  --class-path lib\* ^
+  --module-path %JAVAFX_JMODS%;%JAVA_HOME%\jmods ^
+  --add-modules javafx.controls,javafx.fxml,javafx.graphics,java.sql,java.xml,java.naming,java.desktop,java.management,java.scripting ^
+  --java-options "-Dfile.encoding=UTF-8" ^
+  --icon src\main\resources\images\icono.ico ^
+  --dest target\installer ^
+  --win-shortcut ^
+  --win-menu ^
+  --win-dir-chooser ^
+  --win-menu-group "Tu Empresa" ^
+  --win-upgrade-uuid 12345678-1234-1234-1234-123456789abc
+```
+
+> **Nota:** si omites módulos como `java.sql` o `java.desktop` el runtime generado por `jpackage` quedará “recortado” y, al iniciar, la aplicación se detendrá en el *splash* con errores como `java.lang.NoClassDefFoundError: java/sql/SQLException`. Mantén la lista completa o añade módulos adicionales según tus dependencias.
+
+Sustituye parámetros como `--name`, `--win-menu-group`, `--win-upgrade-uuid` o el icono según tus necesidades.
+
+### Diagnóstico del error `java/sql/SQLException`
+
+Si el ejecutable se cierra justo después del *splash* y en `logs/app.log` aparece un rastro como:
+
+```
+[YYYY-MM-DD HH:MM:SS] ERROR: Fallo durante el splash
+java.lang.NoClassDefFoundError: java/sql/SQLException
+```
+
+significa que el runtime embebido no contiene el módulo `java.sql`. Esto ocurre cuando `jpackage` se ejecuta sin el parámetro `--add-modules` completo (por ejemplo, porque se lanzó una versión anterior del script, se editó el comando manualmente o se reutilizó un instalador generado antes de actualizar la lista de módulos). Vuelve a generar el instalador con el script incluido en este repositorio o asegúrate de pasar explícitamente:
+
+```
+--add-modules javafx.controls,javafx.fxml,javafx.graphics,java.sql,java.xml,java.naming,java.desktop,java.management,java.scripting
+```
+
+Al incluir `java.sql` el runtime vuelve a exponer `java.sql.SQLException` y la secuencia de arranque continuará hasta la ventana de autenticación.
+
+## 5. Alternativa: Launch4j con JVM embebida
+
+Si prefieres un ejecutable ligero que delegue en un JRE empacado manualmente, utiliza [Launch4j](https://launch4j.sourceforge.net/). Este repositorio incluye la plantilla `installer/windows/launch4j-config.xml` que espera la siguiente estructura:
+
+```
+dist/
+├─ GimnasioControl.exe         (resultado de Launch4j)
+├─ GimnasioControl.jar         (renombrado desde target/gimnasio_control-1.0-SNAPSHOT.jar)
+├─ lib/                        (dependencias externas)
+├─ jre/                        (JRE o JDK recortado con jlink)
+└─ recursos adicionales
+```
+
+Abre el archivo XML en la interfaz de Launch4j para ajustar datos como el `outfile`, la ruta del icono o el identificador de tu empresa. Después puedes empaquetar la carpeta `dist/` con instaladores como Inno Setup o NSIS.
+
+---
+
+Con estas herramientas y archivos dispones de todo lo necesario para generar un `.exe` estable y listo para distribución sin errores de tipo “Failed to launch JVM”.

--- a/installer/windows/README.md
+++ b/installer/windows/README.md
@@ -1,0 +1,67 @@
+# Construir el instalador de Windows
+
+El script `build-installer.ps1` automatiza los pasos para generar un `.exe` de Gimnasio Control con `jpackage`. Debe ejecutarse desde PowerShell (Windows 10/11) con permisos para escribir en el directorio `target/installer`.
+
+## Requisitos previos
+
+1. `JAVA_HOME` apuntando a un **JDK 21** que contenga `bin\jpackage.exe`.
+2. `PATH` iniciado con `%JAVA_HOME%\bin` para que Windows utilice el JDK correcto.
+3. `JAVAFX_JMODS` apuntando al directorio que contiene los archivos `*.jmod` de JavaFX (por ejemplo `C:\java\javafx-jmods-21`).
+4. [Apache Maven](https://maven.apache.org/) instalado y disponible en el `PATH`.
+5. PowerShell 5.1 o superior.
+
+Puedes verificar rápidamente que el entorno está listo con:
+
+```powershell
+Get-Command mvn
+Get-Command "$env:JAVA_HOME\bin\jpackage.exe"
+Test-Path $env:JAVAFX_JMODS
+```
+
+Si alguno de los comandos devuelve `False` o un error, corrige las variables de entorno antes de continuar.
+
+## Uso básico
+
+```powershell
+powershell -ExecutionPolicy Bypass -File installer/windows/build-installer.ps1
+```
+
+Al ejecutarlo sin parámetros el script utiliza valores por defecto:
+
+| Parámetro       | Valor por defecto             | Descripción |
+|-----------------|-------------------------------|-------------|
+| `AppName`       | `GimnasioControl`              | Nombre de la aplicación e instalador. |
+| `AppVersion`    | `1.0.0`                        | Se usa para el nombre del archivo `.exe` y metadatos. |
+| `Vendor`        | `Gimnasio Control`             | Fabricante mostrado en el instalador y menú inicio. |
+| `MainClass`     | `Main`                         | Clase principal del proyecto. |
+| `IconPath`      | `src\main\resources\images\icono.ico` | Icono que verá el usuario. |
+| `UpgradeUuid`   | Generado automáticamente       | Identificador para actualizaciones de Windows. |
+
+### Personalización
+
+Ejemplo con valores propios:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File installer/windows/build-installer.ps1 \
+  -AppName "ControlGimnasio" \
+  -AppVersion "1.2.3" \
+  -Vendor "Mi Empresa" \
+  -IconPath "assets\branding\logo.ico" \
+  -UpgradeUuid "0e0465fd-9cbf-4baf-8f62-4f2d4a0b7d63"
+```
+
+## Qué genera el script
+
+* `target/installer/app/` con el `.jar`, dependencias y recursos necesarios.
+* `target/installer/GimnasioControl-1.0.0.exe` (o el nombre según tus parámetros).
+* Un archivo de log de jpackage en la consola para depuración.
+
+El script fija la lista de módulos que debe incluir el runtime (`javafx.controls`, `javafx.fxml`, `javafx.graphics`, `java.sql`, `java.xml`, `java.naming`, `java.desktop`, `java.management`, `java.scripting`). Esta selección evita errores en tiempo de ejecución como `java/sql/SQLException` cuando el instalador se ejecuta en equipos sin un JDK completo.
+
+Si experimentas cierres en el *splash* y el `app.log` registra `NoClassDefFoundError: java/sql/SQLException`, significa que estás ejecutando un instalador generado con una versión antigua del comando (sin `java.sql`). Regenera el paquete con el script actualizado o añade manualmente el parámetro `--add-modules` mencionado arriba.
+
+Repite la ejecución cada vez que haya cambios en el código o dependencias.
+
+## Launch4j como alternativa
+
+Si prefieres crear un ejecutable ligero con una JVM empaquetada manualmente, abre el archivo `launch4j-config.xml` con Launch4j, ajusta rutas e iconos y genera el `.exe`. Posteriormente, empaca el directorio resultante con Inno Setup, NSIS u otra herramienta de instaladores.

--- a/installer/windows/build-installer.ps1
+++ b/installer/windows/build-installer.ps1
@@ -1,0 +1,109 @@
+[CmdletBinding()]
+param(
+    [string]$AppName = "GimnasioControl",
+    [string]$AppVersion = "1.0.0",
+    [string]$Vendor = "Gimnasio Control",
+    [string]$MainClass = "Main",
+    [string]$IconPath = "src\main\resources\images\icono.ico",
+    [string]$UpgradeUuid = "",
+    [string]$JavaFxJmods = $env:JAVAFX_JMODS
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-FileExists {
+    param([string]$Path, [string]$Message)
+    if (-not (Test-Path $Path)) {
+        throw $Message
+    }
+}
+
+function Invoke-CommandChecked {
+    param([string]$Command, [string[]]$Arguments)
+    Write-Host "→ $Command $($Arguments -join ' ')"
+    $process = Start-Process -FilePath $Command -ArgumentList $Arguments -NoNewWindow -PassThru -Wait
+    if ($process.ExitCode -ne 0) {
+        throw "El comando '$Command' terminó con código $($process.ExitCode)."
+    }
+}
+
+$projectRoot = Resolve-Path "$PSScriptRoot\..\.."
+Set-Location $projectRoot
+
+Assert-FileExists -Path $env:JAVA_HOME -Message "JAVA_HOME no está definido o apunta a una ruta inexistente."
+Assert-FileExists -Path (Join-Path $env:JAVA_HOME 'bin\jpackage.exe') -Message "No se encontró jpackage en %JAVA_HOME%\bin. Instala un JDK 21 completo."
+
+if (-not $JavaFxJmods) {
+    throw "Debes definir la variable de entorno JAVAFX_JMODS apuntando a los jmods de JavaFX (por ejemplo C:\\java\\javafx-jmods-21)."
+}
+Assert-FileExists -Path $JavaFxJmods -Message "La ruta definida en JAVAFX_JMODS no existe: $JavaFxJmods"
+
+if (-not (Get-Command mvn -ErrorAction SilentlyContinue)) {
+    throw "No se encontró Maven en el PATH. Instala Maven y agrégalo al PATH."
+}
+
+$installerRoot = Join-Path $projectRoot 'target\installer'
+$appDir = Join-Path $installerRoot 'app'
+$libDir = Join-Path $appDir 'lib'
+
+if (Test-Path $appDir) {
+    Remove-Item $appDir -Recurse -Force
+}
+New-Item -ItemType Directory -Path $libDir -Force | Out-Null
+
+Invoke-CommandChecked -Command 'mvn' -Arguments @('clean', 'package', '--batch-mode')
+Invoke-CommandChecked -Command 'mvn' -Arguments @('dependency:copy-dependencies', '-DincludeScope=runtime', "-DoutputDirectory=$libDir", '--batch-mode')
+
+$artifact = Join-Path $projectRoot 'target\gimnasio_control-1.0-SNAPSHOT.jar'
+Assert-FileExists -Path $artifact -Message "No se generó el jar esperado en target/. Verifica que Maven haya terminado correctamente."
+
+$mainJar = Join-Path $appDir ("{0}.jar" -f $AppName)
+Copy-Item $artifact $mainJar -Force
+
+$extraItems = @('CONFIGURACION.txt', 'lib', 'backups')
+foreach ($item in $extraItems) {
+    $source = Join-Path $projectRoot $item
+    if (Test-Path $source) {
+        Copy-Item $source $appDir -Recurse -Force
+    }
+}
+
+$imagesDir = Join-Path $projectRoot 'src\main\resources\images'
+if (Test-Path $imagesDir) {
+    Copy-Item $imagesDir (Join-Path $appDir 'images') -Recurse -Force
+}
+
+$resolvedIcon = Resolve-Path (Join-Path $projectRoot $IconPath)
+$uuid = if ([string]::IsNullOrWhiteSpace($UpgradeUuid)) { ([guid]::NewGuid()).ToString() } else { $UpgradeUuid }
+
+$modulePath = (Join-Path $env:JAVA_HOME 'jmods') + ';' + (Resolve-Path $JavaFxJmods)
+$jpackage = Join-Path $env:JAVA_HOME 'bin\jpackage.exe'
+
+$requiredModules = 'javafx.controls,javafx.fxml,javafx.graphics,java.sql,java.xml,java.naming,java.desktop,java.management,java.scripting'
+
+$jpackageArgs = @(
+    '--type', 'exe',
+    '--name', $AppName,
+    '--app-version', $AppVersion,
+    '--vendor', $Vendor,
+    '--input', $appDir,
+    '--main-jar', (Split-Path $mainJar -Leaf),
+    '--main-class', $MainClass,
+    '--class-path', 'lib\\*',
+    '--module-path', $modulePath,
+    '--add-modules', $requiredModules,
+    '--java-options', '-Dfile.encoding=UTF-8',
+    '--icon', $resolvedIcon,
+    '--dest', $installerRoot,
+    '--win-dir-chooser',
+    '--win-shortcut',
+    '--win-menu',
+    '--win-menu-group', $Vendor,
+    '--win-upgrade-uuid', $uuid
+)
+
+Write-Host "Ejecutando jpackage..."
+Invoke-CommandChecked -Command $jpackage -Arguments $jpackageArgs
+
+Write-Host "Instalador generado en:" (Join-Path $installerRoot ("{0}-{1}.exe" -f $AppName, $AppVersion))
+Write-Host "UUID de actualización utilizado: $uuid"

--- a/installer/windows/launch4j-config.xml
+++ b/installer/windows/launch4j-config.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch4jConfig>
+  <dontWrapJar>false</dontWrapJar>
+  <headerType>gui</headerType>
+  <jar>..\..\target\installer\app\GimnasioControl.jar</jar>
+  <outfile>..\..\target\installer\GimnasioControl.exe</outfile>
+  <errTitle>Gimnasio Control</errTitle>
+  <cmdLine></cmdLine>
+  <chdir>.</chdir>
+  <priority>normal</priority>
+  <downloadUrl>https://adoptium.net/</downloadUrl>
+  <supportUrl></supportUrl>
+  <stayAlive>false</stayAlive>
+  <restartOnCrash>false</restartOnCrash>
+  <manifest></manifest>
+  <icon>..\..\src\main\resources\images\icono.ico</icon>
+  <classPath>
+    <mainClass>Main</mainClass>
+    <cp>lib\*</cp>
+  </classPath>
+  <jre>
+    <path>jre</path>
+    <bundledJre64Bit>true</bundledJre64Bit>
+    <minVersion>21</minVersion>
+    <jdkPreference>preferJre</jdkPreference>
+    <runtimeBits>64/32</runtimeBits>
+  </jre>
+  <splash>
+    <file>..\..\src\main\resources\images\icono.ico</file>
+    <waitForWindow>true</waitForWindow>
+    <timeout>60</timeout>
+    <timeoutErr>true</timeoutErr>
+  </splash>
+</launch4jConfig>

--- a/src/main/java/controllers/AdminDashboardController.java
+++ b/src/main/java/controllers/AdminDashboardController.java
@@ -11,6 +11,7 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
 import models.Role;
+import util.AppPaths;
 import util.BackupUtil;
 import util.DashboardService;
 import util.SessionManager;
@@ -235,7 +236,7 @@ public class AdminDashboardController implements Initializable {
     @FXML
     private void abrirRespaldos() {
         try {
-            Path dir = Path.of("backups");
+            Path dir = AppPaths.getBackupDirectory();
             if (!Files.exists(dir)) {
                 lblMensaje.setText("No hay respaldos disponibles");
                 return;

--- a/src/main/java/controllers/SplashController.java
+++ b/src/main/java/controllers/SplashController.java
@@ -14,6 +14,8 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import javafx.util.Duration;
 import util.AlertScheduler;
+import util.AppLogger;
+import util.AppPaths;
 import util.AuditoriaScheduler;
 import util.BackupUtil;
 import util.DatabaseUtil;
@@ -44,35 +46,46 @@ public class SplashController {
         Task<Void> task = new Task<Void>() {
             @Override
             protected Void call() throws Exception {
-                // Paso 1: Actualizar progreso inicial (0-30%)
-                for (int i = 0; i < 30; i++) {
-                    updateProgress(i, 100);
-                    Thread.sleep(40);
+                try {
+                    AppLogger.logInfo("Iniciando procesos de arranque desde el splash");
+                    // Paso 1: Actualizar progreso inicial (0-30%)
+                    for (int i = 0; i < 30; i++) {
+                        updateProgress(i, 100);
+                        Thread.sleep(40);
+                    }
+
+                    // Paso 2: Inicializar base de datos
+                    DatabaseUtil.initDatabase();
+                    updateProgress(50, 100);
+
+                    // Paso 3: Iniciar servicios
+                    EstadoClienteService.iniciarActualizacionDiaria();
+                    MantenimientoEquipoScheduler.iniciar();
+                    updateProgress(70, 100);
+
+                    // Paso 4: Programar tareas en segundo plano
+                    AlertScheduler.iniciar();
+                    AuditoriaScheduler.iniciar();
+                    ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+                    scheduler.scheduleAtFixedRate(new BackupUtil(), 0, 1, TimeUnit.DAYS);
+                    updateProgress(90, 100);
+
+                    // Paso 5: Finalizar carga
+                    for (int i = 90; i <= 100; i++) {
+                        updateProgress(i, 100);
+                        Thread.sleep(20);
+                    }
+
+                    AppLogger.logInfo("Splash completado correctamente");
+                    return null;
+                } catch (NoClassDefFoundError error) {
+                    if ("java/sql/SQLException".equals(error.getMessage())) {
+                        throw new IllegalStateException(
+                                "El runtime empacado no incluye el módulo java.sql. Vuelve a generar el instalador con el script " +
+                                        "actualizado para añadir java.sql al runtime.", error);
+                    }
+                    throw error;
                 }
-
-                // Paso 2: Inicializar base de datos
-                DatabaseUtil.initDatabase();
-                updateProgress(50, 100);
-
-                // Paso 3: Iniciar servicios
-                EstadoClienteService.iniciarActualizacionDiaria();
-                MantenimientoEquipoScheduler.iniciar();
-                updateProgress(70, 100);
-
-                // Paso 4: Programar tareas en segundo plano
-                AlertScheduler.iniciar();
-                AuditoriaScheduler.iniciar();
-                ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-                scheduler.scheduleAtFixedRate(new BackupUtil(), 0, 1, TimeUnit.DAYS);
-                updateProgress(90, 100);
-
-                // Paso 5: Finalizar carga
-                for (int i = 90; i <= 100; i++) {
-                    updateProgress(i, 100);
-                    Thread.sleep(20);
-                }
-
-                return null;
             }
         };
 
@@ -82,8 +95,19 @@ public class SplashController {
         // Manejar eventos de la tarea
         task.setOnSucceeded(e -> abrirEntrada());
         task.setOnFailed(e -> {
-            System.err.println("Error en splash screen: " + task.getException().getMessage());
-            abrirEntrada(); // Intentar abrir flujo de autenticación de todas formas
+            Throwable error = task.getException();
+            String message = error != null ? error.getMessage() : "desconocido";
+            System.err.println("Error en splash screen: " + message);
+            AppLogger.logError("Fallo durante el splash", error);
+
+            if (error instanceof IllegalStateException && error.getCause() instanceof NoClassDefFoundError
+                    && "java/sql/SQLException".equals(error.getCause().getMessage())) {
+                mostrarError("El runtime incluido en el instalador no tiene el módulo java.sql. "
+                        + "Vuelve a generar el instalador con el script oficial para incluir java.sql.", true);
+            } else {
+                mostrarError("La aplicación encontró un problema al iniciar. Revisa el archivo de registro en "
+                        + AppPaths.getLogFile(), true);
+            }
         });
 
         // Iniciar tarea en segundo plano
@@ -93,10 +117,6 @@ public class SplashController {
     private void abrirEntrada() {
         Platform.runLater(() -> {
             try {
-                // Cerrar splash
-                Stage splashStage = (Stage) rootPane.getScene().getWindow();
-                splashStage.close();
-
                 // Abrir login
                 int totalUsuarios = DatabaseUtil.getTotalUsuarios();
                 String vista = totalUsuarios == 0 ? "/fxml/crear_admin.fxml" : "/fxml/selector_perfiles.fxml";
@@ -116,9 +136,32 @@ public class SplashController {
                     stage.setTitle("Seleccionar perfil");
                 }
                 stage.setResizable(false);
+                Stage splashStage = (Stage) rootPane.getScene().getWindow();
+                splashStage.close();
                 stage.show();
+                AppLogger.logInfo("Ventana de autenticación mostrada");
             } catch (Exception e) {
                 System.err.println("Error abriendo login: " + e.getMessage());
+                AppLogger.logError("No se pudo abrir la ventana de inicio de sesión", e);
+                mostrarError("No se pudo abrir la ventana de inicio de sesión. Revisa el log para más detalles.");
+            }
+        });
+    }
+
+    private void mostrarError(String mensaje) {
+        mostrarError(mensaje, false);
+    }
+
+    private void mostrarError(String mensaje, boolean cerrarAplicacion) {
+        Platform.runLater(() -> {
+            javafx.scene.control.Alert alert = new javafx.scene.control.Alert(javafx.scene.control.Alert.AlertType.ERROR);
+            alert.setHeaderText(null);
+            alert.setContentText(mensaje);
+            alert.showAndWait();
+            if (cerrarAplicacion) {
+                Stage splashStage = (Stage) rootPane.getScene().getWindow();
+                splashStage.close();
+                Platform.exit();
             }
         });
     }

--- a/src/main/java/util/AppLogger.java
+++ b/src/main/java/util/AppLogger.java
@@ -1,0 +1,65 @@
+package util;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Registro simple de eventos y errores de la aplicación en un archivo local.
+ */
+public final class AppLogger {
+
+    private static final DateTimeFormatter TIMESTAMP = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private AppLogger() {
+    }
+
+    public static void logInfo(String message) {
+        write("INFO", message, null);
+    }
+
+    public static void logError(String message, Throwable error) {
+        write("ERROR", message, error);
+    }
+
+    private static void write(String level, String message, Throwable error) {
+        try {
+            AppPaths.ensureAppDirectories();
+            Path logFile = AppPaths.getLogFile();
+            StringBuilder entry = new StringBuilder()
+                    .append('[')
+                    .append(TIMESTAMP.format(LocalDateTime.now()))
+                    .append("] ")
+                    .append(level)
+                    .append(':')
+                    .append(' ')
+                    .append(message);
+            if (error != null) {
+                entry.append(System.lineSeparator())
+                        .append(stackTrace(error));
+            }
+            entry.append(System.lineSeparator());
+
+            Files.writeString(logFile, entry.toString(), StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException ioException) {
+            System.err.println("No se pudo escribir en el log: " + ioException.getMessage());
+        } catch (Exception e) {
+            System.err.println("Error asegurando directorios de log: " + e.getMessage());
+        }
+    }
+
+    private static String stackTrace(Throwable error) {
+        StringWriter sw = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            error.printStackTrace(pw);
+        }
+        return sw.toString();
+    }
+}

--- a/src/main/java/util/AppPaths.java
+++ b/src/main/java/util/AppPaths.java
@@ -1,0 +1,88 @@
+package util;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Centraliza las rutas de archivos utilizadas por la aplicación para que los datos se
+ * almacenen en una ubicación consistente y con permisos de escritura.
+ */
+public final class AppPaths {
+
+    private static final String ENV_OVERRIDE = "CONTROL_GIMNASIO_HOME";
+    private static final String LOGS_FOLDER_NAME = "logs";
+    private static final String LOG_FILE_NAME = "app.log";
+
+    private AppPaths() {
+    }
+
+    /**
+     * Devuelve el directorio base donde la aplicación almacena datos persistentes.
+     *
+     * <p>Prioriza la variable de entorno {@code CONTROL_GIMNASIO_HOME}. Si no está definida,
+     * se utiliza el directorio de trabajo actual para mantener compatibilidad con
+     * instalaciones existentes.</p>
+     */
+    public static Path getAppHome() {
+        String override = System.getenv(ENV_OVERRIDE);
+        if (override != null && !override.isBlank()) {
+            return Paths.get(override).toAbsolutePath();
+        }
+
+        // Utiliza el directorio de trabajo actual para mantener la base de datos en la
+        // misma ubicación que las instalaciones anteriores.
+        return Paths.get("").toAbsolutePath();
+    }
+
+    /**
+     * Ruta del directorio que contiene la base de datos SQLite.
+     */
+    public static Path getDatabaseDirectory() {
+        return getAppHome().resolve("database");
+    }
+
+    /**
+     * Ruta completa del archivo de base de datos SQLite.
+     */
+    public static Path getDatabaseFile() {
+        return getDatabaseDirectory().resolve("gimnasio.db");
+    }
+
+    /**
+     * Directorio donde se almacenan los respaldos.
+     */
+    public static Path getBackupDirectory() {
+        return getAppHome().resolve("backups");
+    }
+
+    /**
+     * Directorio donde se almacenan los registros de la aplicación.
+     */
+    public static Path getLogsDirectory() {
+        return getAppHome().resolve(LOGS_FOLDER_NAME);
+    }
+
+    /**
+     * Ruta completa del archivo de bitácora principal.
+     */
+    public static Path getLogFile() {
+        return getLogsDirectory().resolve(LOG_FILE_NAME);
+    }
+
+    /**
+     * Garantiza que los directorios base existan antes de acceder a ellos.
+     */
+    public static void ensureAppDirectories() throws Exception {
+        createIfMissing(getAppHome());
+        createIfMissing(getDatabaseDirectory());
+        createIfMissing(getBackupDirectory());
+        createIfMissing(getLogsDirectory());
+    }
+
+    private static void createIfMissing(Path path) throws Exception {
+        if (!Files.exists(path)) {
+            Files.createDirectories(path);
+        }
+    }
+}

--- a/src/main/java/util/BackupUtil.java
+++ b/src/main/java/util/BackupUtil.java
@@ -10,8 +10,8 @@ import java.time.format.DateTimeFormatter;
  * Utilidad para crear respaldos de la base de datos.
  */
 public class BackupUtil implements Runnable {
-    private static final Path DB_PATH = Paths.get("database", "gimnasio.db");
-    private static final Path BACKUP_DIR = Paths.get("backups");
+    private static final Path DB_PATH = AppPaths.getDatabaseFile();
+    private static final Path BACKUP_DIR = AppPaths.getBackupDirectory();
 
     @Override
     public void run() {
@@ -35,6 +35,10 @@ public class BackupUtil implements Runnable {
             Path dir = BACKUP_DIR.resolve(tipo);
             if (!Files.exists(dir)) {
                 Files.createDirectories(dir);
+            }
+            if (!Files.exists(DB_PATH)) {
+                System.out.println("No se encontró la base de datos en " + DB_PATH + ". Se omite respaldo " + tipo + ".");
+                return;
             }
             LocalDateTime ahora = LocalDateTime.now();
             String nombreArchivo;

--- a/src/main/java/util/DatabaseUtil.java
+++ b/src/main/java/util/DatabaseUtil.java
@@ -1,5 +1,6 @@
 package util;
 
+import java.nio.file.Path;
 import java.sql.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -32,12 +33,15 @@ import models.IngresoData;
 import models.EquipoResumen;
 
 public class DatabaseUtil {
-    private static final String URL = "jdbc:sqlite:database/gimnasio.db";
+    private static final Path DB_DIRECTORY = AppPaths.getDatabaseDirectory();
+    private static final Path DB_FILE = AppPaths.getDatabaseFile();
+    private static final String URL = buildJdbcUrl();
     private static final int BUSY_TIMEOUT_MS = 60000;
     private static final DateTimeFormatter SQLITE_DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final Pattern PAGO_ID_PATTERN = Pattern.compile("Pago\\s+(\\d+)", Pattern.CASE_INSENSITIVE);
 
     public static Connection getConnection() throws SQLException {
+        ensureDatabaseDirectory();
         Connection conn = DriverManager.getConnection(URL);
         try (Statement stmt = conn.createStatement()) {
             stmt.execute("PRAGMA journal_mode = WAL");
@@ -46,6 +50,19 @@ public class DatabaseUtil {
             stmt.execute("PRAGMA foreign_keys = ON");
         }
         return conn;
+    }
+
+    private static void ensureDatabaseDirectory() throws SQLException {
+        try {
+            AppPaths.ensureAppDirectories();
+        } catch (Exception e) {
+            throw new SQLException("No se pudo crear el directorio de la base de datos", e);
+        }
+    }
+
+    private static String buildJdbcUrl() {
+        String absolute = DB_FILE.toAbsolutePath().toString();
+        return "jdbc:sqlite:" + absolute.replace('\\', '/');
     }
 
     public static synchronized void initDatabase() {


### PR DESCRIPTION
## Summary
- keep the application data paths rooted in the installation directory unless CONTROL_GIMNASIO_HOME overrides them, preserving the expected database location
- clarify in INSTALLATION.md that gimnasio.db lives under the local database/ folder next to the executable by default

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central responded 403 for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68e54f44ae6c832fae3c64b5798a1b48