### PR TITLE
Add Windows packaging script using jpackage

### DIFF
--- a/docs/BUILD_WINDOWS_EXE.md
+++ b/docs/BUILD_WINDOWS_EXE.md
@@ -1,0 +1,45 @@
+# Creación del instalador `.exe`
+
+Este proyecto incluye un script que automatiza la construcción de un instalador de Windows mediante `jpackage`, sin depender de Launch4j ni Inno Setup.
+
+## Requisitos previos
+
+1. Windows 10/11 de 64 bits.
+2. [Microsoft Visual C++ Redistributable 2015-2022](https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist) instalado (requerido por JavaFX).
+3. JDK 21 (o superior) para Windows, con las herramientas `mvn`, `jlink` y `jpackage` disponibles en el `PATH`.
+   - Puedes usar el JDK de [Gluon](https://gluonhq.com/products/javafx/) o [Oracle](https://www.oracle.com/java/technologies/downloads/) siempre que incluya `jpackage`.
+4. Acceso a internet la primera vez que ejecutes el script, para que Maven descargue las dependencias.
+
+## Pasos
+
+1. Abre una consola de **PowerShell** o **Command Prompt**.
+2. Colócate en la carpeta raíz del proyecto.
+3. Ejecuta el script:
+
+   ```bat
+   scripts\create-windows-exe.bat
+   ```
+
+   El script realizará las siguientes tareas:
+
+   - Compilar el proyecto con Maven (`clean package`).
+   - Copiar las dependencias de tiempo de ejecución en `target/app-libs`.
+   - Generar una imagen de runtime mínima con `jlink` (Java SE).
+   - Empaquetar el instalador `.exe` con `jpackage`, incorporando los directorios `database`, `backups`, `lib` y el archivo `CONFIGURACION.txt`.
+
+4. El instalador resultante se guardará en la carpeta `dist`. El archivo tendrá un nombre similar a `ControlGimnasio-1.0.0.exe`.
+5. Ejecuta el instalador en cualquier máquina Windows para instalar la aplicación. Se crearán accesos directos en el menú inicio y en el escritorio.
+
+## Personalización
+
+- Puedes actualizar el número de versión del instalador cambiando el valor de la propiedad `<app.release.version>` en el `pom.xml`.
+- Si necesitas incluir archivos adicionales, añádelos en el bloque correspondiente del script (`scripts/create-windows-exe.bat`).
+- Para generar solo la imagen portable (sin instalador), puedes cambiar `--type exe` por `--type app-image` en el script.
+
+## Solución de problemas
+
+- **`jlink` o `jpackage` no se reconocen**: asegúrate de ejecutar el script con un JDK completo (no un JRE) y que la variable `JAVA_HOME` apunte a él.
+- **Errores de librerías nativas JavaFX**: verifica que el instalador se ejecute en una arquitectura de 64 bits y que no se hayan eliminado las carpetas `lib`, `database` o `backups`.
+- **Base de datos vacía**: el instalador copia la carpeta `database` tal como se encuentra en el repositorio. Si necesitas datos iniciales, colócalos en esa carpeta antes de empaquetar.
+
+Con estos pasos obtendrás un instalador `.exe` funcional del sistema, idéntico al que ejecutas actualmente desde tu entorno de desarrollo.

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <app.release.version>1.0.0</app.release.version>
     </properties>
 
     <dependencies>
@@ -103,4 +104,47 @@
             <version>3.0.0</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-runtime-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                            <outputDirectory>${project.build.directory}/app-libs</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <app.release.version>1.0.0</app.release.version>
+        <app.release.version>1.1.0</app.release.version>
     </properties>
 
     <dependencies>
@@ -122,7 +122,8 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>Main</mainClass>
+                            <!-- Aquí asegúrate de tener la clase principal correcta -->
+                            <mainClass>Main</mainClass> <!-- Cambia esto si tu clase principal es diferente -->
                         </manifest>
                     </archive>
                 </configuration>
@@ -147,4 +148,6 @@
             </plugin>
         </plugins>
     </build>
+
 </project>
+

--- a/scripts/create-windows-exe.bat
+++ b/scripts/create-windows-exe.bat
@@ -1,0 +1,100 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+REM Directory resolution -----------------------------------------------------
+set "SCRIPT_DIR=%~dp0"
+set "PROJECT_DIR=%SCRIPT_DIR%.."
+cd /d "%PROJECT_DIR%"
+
+REM Resolve Maven coordinates -------------------------------------------------
+for /f "delims=" %%i in ('mvn -q -DforceStdout help:evaluate -Dexpression=project.artifactId') do set "ARTIFACT_ID=%%i"
+for /f "delims=" %%i in ('mvn -q -DforceStdout help:evaluate -Dexpression=project.version') do set "PROJECT_VERSION=%%i"
+for /f "delims=" %%i in ('mvn -q -DforceStdout help:evaluate -Dexpression=app.release.version') do set "APP_VERSION=%%i"
+if not defined APP_VERSION set "APP_VERSION=1.0.0"
+
+set "TARGET_DIR=%PROJECT_DIR%\target"
+set "LIB_DIR=%TARGET_DIR%\app-libs"
+set "INPUT_DIR=%TARGET_DIR%\jpackage-input"
+set "RUNTIME_IMAGE=%TARGET_DIR%\runtime-image"
+set "RESOURCE_DIR=%TARGET_DIR%\jpackage-resources"
+set "DIST_DIR=%PROJECT_DIR%\dist"
+
+REM Build the project --------------------------------------------------------
+call mvn -B -DskipTests clean package
+if errorlevel 1 (
+    echo Maven build failed.
+    exit /b 1
+)
+
+if not exist "%LIB_DIR%" (
+    echo Runtime dependency directory not found: %LIB_DIR%
+    echo Make sure the Maven build ran successfully.
+    exit /b 1
+)
+
+REM Prepare input directory for jpackage -------------------------------------
+if exist "%INPUT_DIR%" rmdir /s /q "%INPUT_DIR%"
+mkdir "%INPUT_DIR%"
+
+set "MAIN_JAR="
+if exist "%TARGET_DIR%\%ARTIFACT_ID%-%PROJECT_VERSION%.jar" (
+    set "MAIN_JAR=%ARTIFACT_ID%-%PROJECT_VERSION%.jar"
+) else (
+    for %%f in ("%TARGET_DIR%\%ARTIFACT_ID%-*.jar") do (
+        set "MAIN_JAR=%%~nxf"
+        goto foundJar
+    )
+)
+:foundJar
+if not defined MAIN_JAR (
+    echo Could not find the application JAR inside %TARGET_DIR%.
+    exit /b 1
+)
+
+copy "%TARGET_DIR%\%MAIN_JAR%" "%INPUT_DIR%" >nul
+xcopy "%LIB_DIR%" "%INPUT_DIR%" /E /I /Y >nul
+
+REM Create custom runtime image ----------------------------------------------
+if exist "%RUNTIME_IMAGE%" rmdir /s /q "%RUNTIME_IMAGE%"
+jlink --strip-debug --no-header-files --no-man-pages --compress=2 --add-modules java.se --output "%RUNTIME_IMAGE%"
+if errorlevel 1 (
+    echo jlink failed. Ensure you are running this script with a JDK that includes jlink.
+    exit /b 1
+)
+
+REM Prepare external resources -----------------------------------------------
+if exist "%RESOURCE_DIR%" rmdir /s /q "%RESOURCE_DIR%"
+mkdir "%RESOURCE_DIR%"
+
+if exist "%PROJECT_DIR%\CONFIGURACION.txt" copy "%PROJECT_DIR%\CONFIGURACION.txt" "%RESOURCE_DIR%" >nul
+if exist "%PROJECT_DIR%\database" xcopy "%PROJECT_DIR%\database" "%RESOURCE_DIR%\database" /E /I /Y >nul
+if exist "%PROJECT_DIR%\backups" xcopy "%PROJECT_DIR%\backups" "%RESOURCE_DIR%\backups" /E /I /Y >nul
+if exist "%PROJECT_DIR%\lib" xcopy "%PROJECT_DIR%\lib" "%RESOURCE_DIR%\lib" /E /I /Y >nul
+
+REM Ensure output directory exists ------------------------------------------
+if not exist "%DIST_DIR%" mkdir "%DIST_DIR%"
+
+REM Package the Windows installer -------------------------------------------
+jpackage ^
+  --type exe ^
+  --name "ControlGimnasio" ^
+  --app-version "%APP_VERSION%" ^
+  --description "Sistema de control de gimnasio" ^
+  --input "%INPUT_DIR%" ^
+  --main-jar "%MAIN_JAR%" ^
+  --main-class Main ^
+  --runtime-image "%RUNTIME_IMAGE%" ^
+  --resource-dir "%RESOURCE_DIR%" ^
+  --dest "%DIST_DIR%" ^
+  --win-shortcut ^
+  --win-menu ^
+  --win-menu-group "ControlGimnasio"
+
+if errorlevel 1 (
+    echo jpackage failed. Review the output above for details.
+    exit /b 1
+)
+
+echo.
+echo Instalador generado en: %DIST_DIR%
+endlocal


### PR DESCRIPTION
## Summary
- configure Maven build to expose the Main class and copy runtime dependencies for packaging
- add a Windows batch script that builds the project and generates a jpackage-based installer without extra tooling
- document the prerequisites and usage instructions for creating the distributable .exe

## Testing
- `mvn -B -DskipTests package` *(fails: Maven Central responded 403 when downloading plugins in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e825ca96b0832fb6798dd5d6c285d1